### PR TITLE
[#8]feat:  글로벌 예외 처리 구현

### DIFF
--- a/src/main/java/bwj/stylehub/common/exception/BusinessException.java
+++ b/src/main/java/bwj/stylehub/common/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package bwj.stylehub.common.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/bwj/stylehub/common/exception/ErrorCode.java
+++ b/src/main/java/bwj/stylehub/common/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     ALREADY_REGISTERED_EMAIL(HttpStatus.CONFLICT, "O001", "이미 일반 회원가입으로 등록된 이메일입니다"),
     ALREADY_REGISTERED_OTHER_PROVIDER(HttpStatus.CONFLICT, "O002", "이미 다른 소셜 계정으로 가입된 이메일입니다"),
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "O003", "지원하지 않는 OAuth Provider입니다"),
-    OAUTH_AUTHENTICATION_FAILED(HttpStatus.BAD_GATEWAY, "O004", "OAuth 인증에 실패했습니다");
+    OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "O004", "OAuth 인증에 실패했습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/bwj/stylehub/common/exception/ErrorCode.java
+++ b/src/main/java/bwj/stylehub/common/exception/ErrorCode.java
@@ -1,0 +1,47 @@
+package bwj.stylehub.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 내부 오류가 발생했습니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "지원하지 않는 HTTP 메서드입니다"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "요청한 리소스를 찾을 수 없습니다"),
+
+    // User
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U001", "이미 사용 중인 이메일입니다"),
+    DUPLICATE_NAME(HttpStatus.CONFLICT, "U002", "이미 사용 중인 닉네임입니다"),
+    DUPLICATE_EMAIL_OR_NAME(HttpStatus.CONFLICT, "U003", "이미 사용 중인 이메일 또는 닉네임입니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U004", "존재하지 않는 사용자입니다"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "U005", "이메일 또는 비밀번호가 일치하지 않습니다"),
+
+    // OAuth
+    ALREADY_REGISTERED_EMAIL(HttpStatus.CONFLICT, "O001", "이미 일반 회원가입으로 등록된 이메일입니다"),
+    ALREADY_REGISTERED_OTHER_PROVIDER(HttpStatus.CONFLICT, "O002", "이미 다른 소셜 계정으로 가입된 이메일입니다"),
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "O003", "지원하지 않는 OAuth Provider입니다"),
+    OAUTH_AUTHENTICATION_FAILED(HttpStatus.BAD_GATEWAY, "O004", "OAuth 인증에 실패했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/bwj/stylehub/common/exception/ErrorResponse.java
+++ b/src/main/java/bwj/stylehub/common/exception/ErrorResponse.java
@@ -1,23 +1,35 @@
 package bwj.stylehub.common.exception;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 public record ErrorResponse(
         int status,
         String code,
-        String message
+        String message,
+        LocalDateTime timestamp,
+        String path,
+        String traceId
 ) {
-    public static ErrorResponse of(ErrorCode errorCode) {
+    public static ErrorResponse of(ErrorCode errorCode, String path) {
         return new ErrorResponse(
                 errorCode.getStatus().value(),
                 errorCode.getCode(),
-                errorCode.getMessage()
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                path,
+                UUID.randomUUID().toString()
         );
     }
 
-    public static ErrorResponse of(ErrorCode errorCode, String message) {
+    public static ErrorResponse of(ErrorCode errorCode, String message, String path) {
         return new ErrorResponse(
                 errorCode.getStatus().value(),
                 errorCode.getCode(),
-                message
+                message,
+                LocalDateTime.now(),
+                path,
+                UUID.randomUUID().toString()
         );
     }
 }

--- a/src/main/java/bwj/stylehub/common/exception/ErrorResponse.java
+++ b/src/main/java/bwj/stylehub/common/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package bwj.stylehub.common.exception;
+
+public record ErrorResponse(
+        int status,
+        String code,
+        String message
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                message
+        );
+    }
+}

--- a/src/main/java/bwj/stylehub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bwj/stylehub/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package bwj.stylehub.common.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+/**
+ * 글로벌 예외 처리 핸들러
+ *
+ * @author bwj
+ * @since 2026-03-23
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -19,17 +26,17 @@ public class GlobalExceptionHandler {
 
     // 비즈니스 예외 — throw new BusinessException(ErrorCode.XXX)
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e, HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("Business exception: {}", errorCode);
         return ResponseEntity
                 .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
+                .body(ErrorResponse.of(errorCode, request.getRequestURI()));
     }
 
     // Bean Validation 실패 — @Valid 검증 실패
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpServletRequest request) {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .findFirst()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
@@ -37,57 +44,57 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message, request.getRequestURI()));
     }
 
     // PathVariable, RequestParam 타입 변환 실패
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e, HttpServletRequest request) {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT));
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, request.getRequestURI()));
     }
 
     // 필수 RequestParam 누락 — ?code= 없이 요청
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(MissingServletRequestParameterException e) {
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(MissingServletRequestParameterException e, HttpServletRequest request) {
         String message = e.getParameterName() + " 파라미터가 필요합니다";
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message, request.getRequestURI()));
     }
 
     // JSON 파싱 실패 — 잘못된 JSON body, 타입 불일치
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, "요청 본문을 읽을 수 없습니다"));
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, "요청 본문을 읽을 수 없습니다", request.getRequestURI()));
     }
 
     // 지원하지 않는 HTTP 메서드 — POST 엔드포인트에 GET 요청
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
         String message = e.getMethod() + " 메서드는 지원하지 않습니다";
         return ResponseEntity
                 .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus())
-                .body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, message));
+                .body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, message, request.getRequestURI()));
     }
 
     // 존재하지 않는 API 경로
     @ExceptionHandler(NoResourceFoundException.class)
-    protected ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
+    protected ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e, HttpServletRequest request) {
         return ResponseEntity
                 .status(ErrorCode.RESOURCE_NOT_FOUND.getStatus())
-                .body(ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND));
+                .body(ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, request.getRequestURI()));
     }
 
     // 예상치 못한 모든 예외
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.error("Unhandled exception", e);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI()));
     }
 }

--- a/src/main/java/bwj/stylehub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bwj/stylehub/common/exception/GlobalExceptionHandler.java
@@ -21,6 +21,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
+        log.warn("Business exception: {}", errorCode);
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
@@ -81,7 +82,7 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND));
     }
 
-    // 예상치 못한 모든 예외 — 안전망
+    // 예상치 못한 모든 예외
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Unhandled exception", e);

--- a/src/main/java/bwj/stylehub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bwj/stylehub/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package bwj.stylehub.common.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    // 비즈니스 예외 — throw new BusinessException(ErrorCode.XXX)
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    // Bean Validation 실패 — @Valid 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+    }
+
+    // PathVariable, RequestParam 타입 변환 실패
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT));
+    }
+
+    // 필수 RequestParam 누락 — ?code= 없이 요청
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(MissingServletRequestParameterException e) {
+        String message = e.getParameterName() + " 파라미터가 필요합니다";
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+    }
+
+    // JSON 파싱 실패 — 잘못된 JSON body, 타입 불일치
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, "요청 본문을 읽을 수 없습니다"));
+    }
+
+    // 지원하지 않는 HTTP 메서드 — POST 엔드포인트에 GET 요청
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        String message = e.getMethod() + " 메서드는 지원하지 않습니다";
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, message));
+    }
+
+    // 존재하지 않는 API 경로
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
+        return ResponseEntity
+                .status(ErrorCode.RESOURCE_NOT_FOUND.getStatus())
+                .body(ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    // 예상치 못한 모든 예외 — 안전망
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}


### PR DESCRIPTION
 ## #️⃣ Issue Number

- #8 

## 📝 요약(Summary)
 - 모든 예외가 IllegalArgumentException으로 처리되어 상황별 HTTP 상태 코드 구분이 불가능한 문제를 해결했습니다.
  - BusinessException + ErrorCode + GlobalExceptionHandler를 도입하여 일관된 에러 응답 형식을 제공합니다.


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

- [x] 새로운 기능 추가

## 주요 설계 결정
 - ErrorCode enum 중앙 관리 : 모든 도메인의 에러 코드를 한 곳에서 관리하여 코드 충돌 방지 및 API 문서화 용이
 - BusinessException 단일 클래스 :  도메인별 예외 클래스를 만들지 않고 ErrorCode로 구분하여 클래스 폭발 방지
 - ErrorResponse 통일 응답 : status, code, message 3개 필드로 디버깅과 로깅에 용이한 구조




## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
-  회원 API PR 머지 후 IllegalArgumentException을 BusinessException(ErrorCode.XXX)으로 교체하는 후속 작업이 필요합니다.


<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->