### PR TITLE
[#15] refact:글로벌 예외처리 리팩토링

### DIFF
--- a/src/main/java/ccommit/stylehub/common/exception/BusinessException.java
+++ b/src/main/java/ccommit/stylehub/common/exception/BusinessException.java
@@ -1,4 +1,4 @@
-package bwj.stylehub.common.exception;
+package ccommit.stylehub.common.exception;
 
 public class BusinessException extends RuntimeException {
 

--- a/src/main/java/ccommit/stylehub/common/exception/BusinessException.java
+++ b/src/main/java/ccommit/stylehub/common/exception/BusinessException.java
@@ -1,5 +1,15 @@
 package ccommit.stylehub.common.exception;
 
+/**
+ * @author WonJin Bae
+ * @created 2026/03/22
+ * @modified 2026/03/24 by WonJin - refactor: bwj 패키지명 ccommit으로 변경
+ *
+ * <p>
+ * 비즈니스 로직에서 발생하는 예외를 표현하는 커스텀 런타임 예외이다.
+ * ErrorCode를 감싸 GlobalExceptionHandler에서 일관된 에러 응답을 생성한다.
+ * </p>
+ */
 public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;

--- a/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
+++ b/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package bwj.stylehub.common.exception;
+package ccommit.stylehub.common.exception;
 
 import org.springframework.http.HttpStatus;
 
@@ -21,7 +21,12 @@ public enum ErrorCode {
     ALREADY_REGISTERED_EMAIL(HttpStatus.CONFLICT, "O001", "이미 일반 회원가입으로 등록된 이메일입니다"),
     ALREADY_REGISTERED_OTHER_PROVIDER(HttpStatus.CONFLICT, "O002", "이미 다른 소셜 계정으로 가입된 이메일입니다"),
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "O003", "지원하지 않는 OAuth Provider입니다"),
-    OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "O004", "OAuth 인증에 실패했습니다");
+    OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "O004", "OAuth 인증에 실패했습니다"),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "로그인이 필요합니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다"),
+    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "A003", "세션이 만료되었습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
+++ b/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
@@ -2,6 +2,16 @@ package ccommit.stylehub.common.exception;
 
 import org.springframework.http.HttpStatus;
 
+/**
+ * @author WonJin Bae
+ * @created 2026/03/22
+ * @modified 2026/03/24 by WonJin - refactor: bwj 패키지명 ccommit으로 변경, Auth 에러코드 추가
+ *
+ * <p>
+ * 애플리케이션 전역에서 사용하는 에러 코드를 정의한다.
+ * HttpStatus, 에러 코드, 메시지를 하나로 관리한다.
+ * </p>
+ */
 public enum ErrorCode {
 
     // Common

--- a/src/main/java/ccommit/stylehub/common/exception/ErrorResponse.java
+++ b/src/main/java/ccommit/stylehub/common/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package bwj.stylehub.common.exception;
+package ccommit.stylehub.common.exception;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/ccommit/stylehub/common/exception/ErrorResponse.java
+++ b/src/main/java/ccommit/stylehub/common/exception/ErrorResponse.java
@@ -3,6 +3,16 @@ package ccommit.stylehub.common.exception;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * @author WonJin Bae
+ * @created 2026/03/22
+ * @modified 2026/03/24 by WonJin - refactor: bwj 패키지명 ccommit으로 변경, timestamp/path/traceId 필드 추가
+ *
+ * <p>
+ * 클라이언트에 반환되는 에러 응답 포맷을 정의한다.
+ * timestamp, path, traceId로 장애 추적 및 모니터링을 지원한다.
+ * </p>
+ */
 public record ErrorResponse(
         int status,
         String code,

--- a/src/main/java/ccommit/stylehub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ccommit/stylehub/common/exception/GlobalExceptionHandler.java
@@ -14,10 +14,14 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
- * 글로벌 예외 처리 핸들러
+ * @author WonJin Bae
+ * @created 2026/03/22
+ * @modified 2026/03/24 by WonJin - refactor: bwj 패키지명 ccommit으로 변경, log.warn/error 분리, timestamp/path/traceId 추가
  *
- * @author bwj
- * @since 2026-03-23
+ * <p>
+ * 애플리케이션 전역 예외를 처리하는 핸들러이다.
+ * 비즈니스 예외는 warn, 시스템 예외는 error로 로그 레벨을 분리한다.
+ * </p>
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/ccommit/stylehub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ccommit/stylehub/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package bwj.stylehub.common.exception;
+package ccommit.stylehub.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;


### PR DESCRIPTION
 ## #️⃣ Issue Number

- #15 

## 📝 요약(Summary)
 - 모든 예외가 IllegalArgumentException으로 처리되어 상황별 HTTP 상태 코드 구분이 불가능한 문제를 해결했습니다.
  - 예외 메세지 출력형식을 다음과 같이 보여지도록 구현하였습니다.

```jason
  {                                                                                                                                                                                
    "status": 409,                                                                                                                                                                 
    "code": "U001",                                         
    "message": "이미 사용 중인 이메일입니다",
    "timestamp": "2026-03-23T14:32:10.123",  
    "path": "/api/v1/users",                                                                                                                                                          
    "traceId": "f3a9c2b1-8d4a-4f2e-9c6d-1a2b3c4d5e6f"                                                                                                                              
  }                                                                                                                                                                                
       
```


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

- [x] 코드리팩토링
 




## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
-  회원 API PR 머지 후 IllegalArgumentException을 BusinessException(ErrorCode.XXX)으로 교체하는 후속 작업이 필요합니다.


<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->