### PR TITLE
 [#27]feat: 선착순 쿠폰 발급 기능 구현 (비관적 락, 쿠폰 이벤트 CRUD, 전략 패턴 할인 계산)

### DIFF
--- a/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
+++ b/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
@@ -63,6 +63,16 @@ public enum ErrorCode {
     CANCEL_NOT_ALLOWED_SHIPPING(HttpStatus.BAD_REQUEST, "PM007", "배송 중에는 취소할 수 없습니다"),
     REFUND_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "PM008", "환불 가능 기간이 지났습니다"),
 
+    // Coupon
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 쿠폰 이벤트입니다"),
+    COUPON_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "CP002", "비활성화된 쿠폰 이벤트입니다"),
+    COUPON_NOT_STARTED(HttpStatus.BAD_REQUEST, "CP003", "아직 시작되지 않은 쿠폰 이벤트입니다"),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "CP004", "만료된 쿠폰 이벤트입니다"),
+    COUPON_SOLD_OUT(HttpStatus.CONFLICT, "CP005", "쿠폰이 모두 소진되었습니다"),
+    COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, "CP006", "이미 발급받은 쿠폰입니다"),
+    INVALID_DISCOUNT_VALUE(HttpStatus.BAD_REQUEST, "CP007", "할인 값이 유효하지 않습니다"),
+    INVALID_COUPON_PERIOD(HttpStatus.BAD_REQUEST, "CP008", "쿠폰 유효기간이 올바르지 않습니다"),
+
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "로그인이 필요합니다"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다"),

--- a/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
+++ b/src/main/java/ccommit/stylehub/common/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
     COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, "CP006", "이미 발급받은 쿠폰입니다"),
     INVALID_DISCOUNT_VALUE(HttpStatus.BAD_REQUEST, "CP007", "할인 값이 유효하지 않습니다"),
     INVALID_COUPON_PERIOD(HttpStatus.BAD_REQUEST, "CP008", "쿠폰 유효기간이 올바르지 않습니다"),
+    INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "CP009", "쿠폰 타입과 스토어 설정이 일치하지 않습니다"),
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "로그인이 필요합니다"),

--- a/src/main/java/ccommit/stylehub/coupon/controller/CouponController.java
+++ b/src/main/java/ccommit/stylehub/coupon/controller/CouponController.java
@@ -1,0 +1,103 @@
+package ccommit.stylehub.coupon.controller;
+
+import ccommit.stylehub.common.config.RequiredRole;
+import ccommit.stylehub.common.util.SessionUtils;
+import ccommit.stylehub.coupon.dto.request.CouponEventCreateRequest;
+import ccommit.stylehub.coupon.dto.request.CouponEventUpdateRequest;
+import ccommit.stylehub.coupon.dto.response.CouponEventResponse;
+import ccommit.stylehub.coupon.dto.response.UserCouponResponse;
+import ccommit.stylehub.coupon.service.CouponService;
+import ccommit.stylehub.user.enums.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/09
+ *
+ * <p>
+ * 쿠폰 이벤트 생성(STORE/ADMIN) 및 선착순 발급(USER) API를 제공한다.
+ * </p>
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CouponController {
+
+    private final CouponService couponService;
+
+    // STORE: 스토어 쿠폰 이벤트 생성
+    @PostMapping("/stores/{storeId}/coupon-events")
+    @RequiredRole(UserRole.STORE)
+    public ResponseEntity<CouponEventResponse> createStoreCouponEvent(
+            @PathVariable Long storeId,
+            @Valid @RequestBody CouponEventCreateRequest request,
+            HttpServletRequest httpRequest) {
+        Long userId = SessionUtils.getUserId(httpRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(couponService.createStoreCouponEvent(userId, storeId, request));
+    }
+
+    // ADMIN: 플랫폼 쿠폰 이벤트 생성
+    @PostMapping("/admin/coupon-events")
+    @RequiredRole(UserRole.ADMIN)
+    public ResponseEntity<CouponEventResponse> createPlatformCouponEvent(
+            @Valid @RequestBody CouponEventCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(couponService.createPlatformCouponEvent(request));
+    }
+
+    // ADMIN: 쿠폰 이벤트 수정
+    @PatchMapping("/admin/coupon-events/{couponEventId}")
+    @RequiredRole(UserRole.ADMIN)
+    public ResponseEntity<CouponEventResponse> updateCouponEvent(
+            @PathVariable Long couponEventId,
+            @Valid @RequestBody CouponEventUpdateRequest request) {
+        return ResponseEntity.ok(couponService.updateCouponEvent(couponEventId, request));
+    }
+
+    // ADMIN: 쿠폰 이벤트 비활성화
+    @PatchMapping("/admin/coupon-events/{couponEventId}/deactivate")
+    @RequiredRole(UserRole.ADMIN)
+    public ResponseEntity<Void> deactivateCouponEvent(@PathVariable Long couponEventId) {
+        couponService.deactivateCouponEvent(couponEventId);
+        return ResponseEntity.ok().build();
+    }
+
+    // USER: 내 쿠폰 목록 조회
+    @GetMapping("/coupon-events/my")
+    @RequiredRole(UserRole.USER)
+    public ResponseEntity<List<UserCouponResponse>> getMyCoupons(HttpServletRequest httpRequest) {
+        Long userId = SessionUtils.getUserId(httpRequest);
+        return ResponseEntity.ok(couponService.getMyCoupons(userId));
+    }
+
+    // USER: 선착순 쿠폰 발급
+    @PostMapping("/coupon-events/{couponEventId}/issue")
+    @RequiredRole(UserRole.USER)
+    public ResponseEntity<Void> issueCoupon(
+            @PathVariable Long couponEventId,
+            HttpServletRequest httpRequest) {
+        Long userId = SessionUtils.getUserId(httpRequest);
+        couponService.issueCoupon(userId, couponEventId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 활성 쿠폰 이벤트 목록 조회 (공개)
+    @GetMapping("/coupon-events")
+    public ResponseEntity<List<CouponEventResponse>> getActiveCouponEvents() {
+        return ResponseEntity.ok(couponService.getActiveCouponEvents());
+    }
+}

--- a/src/main/java/ccommit/stylehub/coupon/dto/request/CouponEventCreateRequest.java
+++ b/src/main/java/ccommit/stylehub/coupon/dto/request/CouponEventCreateRequest.java
@@ -1,0 +1,49 @@
+package ccommit.stylehub.coupon.dto.request;
+
+import ccommit.stylehub.coupon.enums.DiscountType;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/09
+ *
+ * <p>
+ * 쿠폰 이벤트 생성 요청 DTO이다.
+ * </p>
+ */
+public record CouponEventCreateRequest(
+
+        @NotBlank(message = "쿠폰 이벤트명은 필수입니다")
+        @Size(max = 20, message = "쿠폰 이벤트명은 20자 이내여야 합니다")
+        String name,
+
+        @NotNull(message = "할인 유형은 필수입니다")
+        DiscountType discountType,
+
+        @NotNull(message = "할인 값은 필수입니다")
+        @Positive(message = "할인 값은 0보다 커야 합니다")
+        Integer discountValue,
+
+        @NotNull(message = "최소 주문 금액은 필수입니다")
+        @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다")
+        Integer minOrderAmount,
+
+        @NotNull(message = "발행 수량은 필수입니다")
+        @Positive(message = "발행 수량은 0보다 커야 합니다")
+        Integer issueCount,
+
+        @NotNull(message = "시작일은 필수입니다")
+        @Future(message = "시작일은 현재보다 이후여야 합니다")
+        LocalDateTime startedAt,
+
+        @NotNull(message = "만료일은 필수입니다")
+        @Future(message = "만료일은 현재보다 이후여야 합니다")
+        LocalDateTime expiredAt
+) {}

--- a/src/main/java/ccommit/stylehub/coupon/dto/request/CouponEventUpdateRequest.java
+++ b/src/main/java/ccommit/stylehub/coupon/dto/request/CouponEventUpdateRequest.java
@@ -1,0 +1,36 @@
+package ccommit.stylehub.coupon.dto.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/09
+ *
+ * <p>
+ * 쿠폰 이벤트 수정 요청 DTO이다.
+ * 기간, 수량, 최소 주문 금액을 변경할 수 있다.
+ * </p>
+ */
+public record CouponEventUpdateRequest(
+
+        @NotNull(message = "발행 수량은 필수입니다")
+        @Positive(message = "발행 수량은 0보다 커야 합니다")
+        Integer issueCount,
+
+        @NotNull(message = "최소 주문 금액은 필수입니다")
+        @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다")
+        Integer minOrderAmount,
+
+        @NotNull(message = "시작일은 필수입니다")
+        @Future(message = "시작일은 현재보다 이후여야 합니다")
+        LocalDateTime startedAt,
+
+        @NotNull(message = "만료일은 필수입니다")
+        @Future(message = "만료일은 현재보다 이후여야 합니다")
+        LocalDateTime expiredAt
+) {}

--- a/src/main/java/ccommit/stylehub/coupon/dto/response/CouponEventResponse.java
+++ b/src/main/java/ccommit/stylehub/coupon/dto/response/CouponEventResponse.java
@@ -1,6 +1,7 @@
 package ccommit.stylehub.coupon.dto.response;
 
 import ccommit.stylehub.coupon.entity.CouponEvent;
+import ccommit.stylehub.coupon.enums.CouponType;
 import ccommit.stylehub.coupon.enums.DiscountType;
 import lombok.Builder;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 /**
  * @author WonJin Bae
  * @created 2026/04/09
+ * @modified 2026/04/16 by WonJin - refactor: couponType 필드 추가
  *
  * <p>
  * 쿠폰 이벤트 응답 DTO이다.
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 @Builder
 public record CouponEventResponse(
         Long couponEventId,
+        CouponType couponType,
         Long storeId,
         String storeName,
         String name,
@@ -33,6 +36,7 @@ public record CouponEventResponse(
     public static CouponEventResponse from(CouponEvent event) {
         return CouponEventResponse.builder()
                 .couponEventId(event.getCouponEventId())
+                .couponType(event.getCouponType())
                 .storeId(event.getStore() != null ? event.getStore().getStoreId() : null)
                 .storeName(event.getStore() != null ? event.getStore().getName() : "StyleHub")
                 .name(event.getName())

--- a/src/main/java/ccommit/stylehub/coupon/dto/response/CouponEventResponse.java
+++ b/src/main/java/ccommit/stylehub/coupon/dto/response/CouponEventResponse.java
@@ -1,0 +1,50 @@
+package ccommit.stylehub.coupon.dto.response;
+
+import ccommit.stylehub.coupon.entity.CouponEvent;
+import ccommit.stylehub.coupon.enums.DiscountType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/09
+ *
+ * <p>
+ * 쿠폰 이벤트 응답 DTO이다.
+ * </p>
+ */
+@Builder
+public record CouponEventResponse(
+        Long couponEventId,
+        Long storeId,
+        String storeName,
+        String name,
+        DiscountType discountType,
+        Integer discountValue,
+        Integer minOrderAmount,
+        Integer issueCount,
+        Integer issuedCount,
+        LocalDateTime startedAt,
+        LocalDateTime expiredAt,
+        Boolean active,
+        LocalDateTime createdAt
+) {
+    public static CouponEventResponse from(CouponEvent event) {
+        return CouponEventResponse.builder()
+                .couponEventId(event.getCouponEventId())
+                .storeId(event.getStore() != null ? event.getStore().getStoreId() : null)
+                .storeName(event.getStore() != null ? event.getStore().getName() : "StyleHub")
+                .name(event.getName())
+                .discountType(event.getDiscountType())
+                .discountValue(event.getDiscountValue())
+                .minOrderAmount(event.getMinOrderAmount())
+                .issueCount(event.getIssueCount())
+                .issuedCount(event.getIssuedCount())
+                .startedAt(event.getStartedAt())
+                .expiredAt(event.getExpiredAt())
+                .active(event.getActive())
+                .createdAt(event.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/ccommit/stylehub/coupon/entity/CouponEvent.java
+++ b/src/main/java/ccommit/stylehub/coupon/entity/CouponEvent.java
@@ -1,6 +1,8 @@
 package ccommit.stylehub.coupon.entity;
 
 import ccommit.stylehub.common.entity.BaseEntity;
+import ccommit.stylehub.common.exception.BusinessException;
+import ccommit.stylehub.common.exception.ErrorCode;
 import ccommit.stylehub.coupon.enums.DiscountType;
 import ccommit.stylehub.store.entity.Store;
 import jakarta.persistence.Column;
@@ -27,6 +29,7 @@ import java.time.LocalDateTime;
  * @created 2026/03/21 08:17
  * @modified 2026/03/14 19:00 by WonJin - refactor: 모든 엔티티 클래스의 JPA 와일드카드 import를 명시적 import로 교체
  * @modified 2026/03/21 08:17 by WonJin - refactor: bwj 패키지명 ccommit으로 변경
+ * @modified 2026/04/09 by WonJin - feat: issuedCount 필드 추가, 선착순 발급 검증 메서드 추가
  *
  * <p>
  * 관리자 또는 스토어가 발행하는 쿠폰 이벤트를 관리한다.
@@ -47,7 +50,7 @@ public class CouponEvent extends BaseEntity {
     private Long couponEventId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "store_id", nullable = true)
+    @JoinColumn(name = "store_id")
     private Store store;
 
     @Column(nullable = false, length = 20)
@@ -67,6 +70,10 @@ public class CouponEvent extends BaseEntity {
     @Column(name = "issue_count", nullable = false)
     private Integer issueCount;
 
+    @Column(name = "issued_count", nullable = false)
+    @Builder.Default
+    private Integer issuedCount = 0;
+
     @Column(name = "started_at", nullable = false)
     private LocalDateTime startedAt;
 
@@ -74,11 +81,10 @@ public class CouponEvent extends BaseEntity {
     private LocalDateTime expiredAt;
 
     @Column(name = "is_active", nullable = false)
-    @Builder.Default  // 빌더로 객체 생성 시 이 필드를 명시하지 않으면 선언된 기본값을 사용한다
-
+    @Builder.Default
     private Boolean active = true;
 
-    // store가 null이면 플랫폼 쿠폰, 값이 있으면 스토어 쿠폰
+    // 스토어 쿠폰 생성
     public static CouponEvent create(Store store, String name, DiscountType discountType,
                                      Integer discountValue, Integer minOrderAmount,
                                      Integer issueCount, LocalDateTime startedAt,
@@ -93,5 +99,52 @@ public class CouponEvent extends BaseEntity {
                 .startedAt(startedAt)
                 .expiredAt(expiredAt)
                 .build();
+    }
+
+    // 플랫폼(관리자) 쿠폰 생성 — store = null
+    public static CouponEvent createPlatform(String name, DiscountType discountType,
+                                             Integer discountValue, Integer minOrderAmount,
+                                             Integer issueCount, LocalDateTime startedAt,
+                                             LocalDateTime expiredAt) {
+        return CouponEvent.builder()
+                .name(name)
+                .discountType(discountType)
+                .discountValue(discountValue)
+                .minOrderAmount(minOrderAmount)
+                .issueCount(issueCount)
+                .startedAt(startedAt)
+                .expiredAt(expiredAt)
+                .build();
+    }
+
+    public void increaseIssuedCount() {
+        if (this.issuedCount >= this.issueCount) {
+            throw new BusinessException(ErrorCode.COUPON_SOLD_OUT);
+        }
+        this.issuedCount++;
+    }
+
+    public void update(Integer issueCount, Integer minOrderAmount,
+                       LocalDateTime startedAt, LocalDateTime expiredAt) {
+        this.issueCount = issueCount;
+        this.minOrderAmount = minOrderAmount;
+        this.startedAt = startedAt;
+        this.expiredAt = expiredAt;
+    }
+
+    public int calculateDiscount(int orderAmount) {
+        return discountType.calculate(orderAmount, discountValue);
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiredAt);
+    }
+
+    public boolean isNotStarted() {
+        return LocalDateTime.now().isBefore(this.startedAt);
     }
 }

--- a/src/main/java/ccommit/stylehub/coupon/entity/CouponEvent.java
+++ b/src/main/java/ccommit/stylehub/coupon/entity/CouponEvent.java
@@ -3,6 +3,7 @@ package ccommit.stylehub.coupon.entity;
 import ccommit.stylehub.common.entity.BaseEntity;
 import ccommit.stylehub.common.exception.BusinessException;
 import ccommit.stylehub.common.exception.ErrorCode;
+import ccommit.stylehub.coupon.enums.CouponType;
 import ccommit.stylehub.coupon.enums.DiscountType;
 import ccommit.stylehub.store.entity.Store;
 import jakarta.persistence.Column;
@@ -30,10 +31,12 @@ import java.time.LocalDateTime;
  * @modified 2026/03/14 19:00 by WonJin - refactor: 모든 엔티티 클래스의 JPA 와일드카드 import를 명시적 import로 교체
  * @modified 2026/03/21 08:17 by WonJin - refactor: bwj 패키지명 ccommit으로 변경
  * @modified 2026/04/09 by WonJin - feat: issuedCount 필드 추가, 선착순 발급 검증 메서드 추가
+ * @modified 2026/04/16 by WonJin - refactor: couponType 필드 추가, PLATFORM/STORE 명시적 구분
  *
  * <p>
  * 관리자 또는 스토어가 발행하는 쿠폰 이벤트를 관리한다.
- * store 필드의 null 여부로 관리자/스토어 쿠폰을 구분한다.
+ * couponType으로 PLATFORM/STORE를 명시적으로 구분하며,
+ * 생성 시 타입-스토어 관계의 불변식을 강제한다.
  * </p>
  */
 
@@ -52,6 +55,10 @@ public class CouponEvent extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "coupon_type", nullable = false)
+    private CouponType couponType;
 
     @Column(nullable = false, length = 20)
     private String name;
@@ -84,13 +91,17 @@ public class CouponEvent extends BaseEntity {
     @Builder.Default
     private Boolean active = true;
 
-    // 스토어 쿠폰 생성
+    // 스토어 쿠폰 생성 — couponType = STORE, store != null 불변식
     public static CouponEvent create(Store store, String name, DiscountType discountType,
                                      Integer discountValue, Integer minOrderAmount,
                                      Integer issueCount, LocalDateTime startedAt,
                                      LocalDateTime expiredAt) {
+        if (store == null) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_TYPE);
+        }
         return CouponEvent.builder()
                 .store(store)
+                .couponType(CouponType.STORE)
                 .name(name)
                 .discountType(discountType)
                 .discountValue(discountValue)
@@ -101,12 +112,13 @@ public class CouponEvent extends BaseEntity {
                 .build();
     }
 
-    // 플랫폼(관리자) 쿠폰 생성 — store = null
+    // 플랫폼(관리자) 쿠폰 생성 — couponType = PLATFORM, store = null 불변식
     public static CouponEvent createPlatform(String name, DiscountType discountType,
                                              Integer discountValue, Integer minOrderAmount,
                                              Integer issueCount, LocalDateTime startedAt,
                                              LocalDateTime expiredAt) {
         return CouponEvent.builder()
+                .couponType(CouponType.PLATFORM)
                 .name(name)
                 .discountType(discountType)
                 .discountValue(discountValue)

--- a/src/main/java/ccommit/stylehub/coupon/entity/UserCoupon.java
+++ b/src/main/java/ccommit/stylehub/coupon/entity/UserCoupon.java
@@ -2,7 +2,18 @@ package ccommit.stylehub.coupon.entity;
 
 import ccommit.stylehub.coupon.enums.CouponStatus;
 import ccommit.stylehub.user.entity.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +27,7 @@ import java.time.LocalDateTime;
  * @created 2026/03/21 08:17
  * @modified 2026/03/14 19:00 by WonJin - refactor: 모든 엔티티 클래스의 JPA 와일드카드 import를 명시적 import로 교체
  * @modified 2026/03/21 08:17 by WonJin - refactor: bwj 패키지명 ccommit으로 변경
+ * @modified 2026/04/09 by WonJin - feat: 와일드카드 import 수정, UniqueConstraint 추가
  *
  * <p>
  * 사용자에게 발급된 개별 쿠폰 인스턴스를 관리한다.
@@ -24,7 +36,9 @@ import java.time.LocalDateTime;
  */
 
 @Entity
-@Table(name = "user_coupons")
+@Table(name = "user_coupons", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "coupon_event_id"})
+})
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/ccommit/stylehub/coupon/entity/UserCoupon.java
+++ b/src/main/java/ccommit/stylehub/coupon/entity/UserCoupon.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
  * @modified 2026/03/14 19:00 by WonJin - refactor: 모든 엔티티 클래스의 JPA 와일드카드 import를 명시적 import로 교체
  * @modified 2026/03/21 08:17 by WonJin - refactor: bwj 패키지명 ccommit으로 변경
  * @modified 2026/04/09 by WonJin - feat: 와일드카드 import 수정, UniqueConstraint 추가
+ * @modified 2026/04/16 by WonJin - docs: (user_id, coupon_event_id) UNIQUE 제약 사용 이유 주석 추가
  *
  * <p>
  * 사용자에게 발급된 개별 쿠폰 인스턴스를 관리한다.
@@ -36,6 +37,28 @@ import java.time.LocalDateTime;
  */
 
 @Entity
+/*
+ * (user_id, coupon_event_id) 복합 UNIQUE 제약을 두는 이유:
+ *
+ * 1) 중복 발급의 최종 방어선
+ *    - 서비스 레이어(CouponService.checkDuplicateIssue)에서 1차 체크를 수행하지만,
+ *      동시성 경합 상황에서 두 트랜잭션이 체크 단계를 동시에 통과한 뒤
+ *      각자 save를 시도할 가능성이 있다.
+ *    - DB UNIQUE 제약으로 최종 방어하여 같은 사용자가 동일 쿠폰 이벤트를
+ *      두 번 발급받는 것을 원천 차단한다.
+ *
+ * 2) 비즈니스 규칙을 스키마로 표현
+ *    - "한 사용자는 한 쿠폰 이벤트당 최대 1장만 소유" 이라는 도메인 규칙을
+ *      애플리케이션 코드가 아닌 스키마 수준에서 명시하여 일관성을 보장한다.
+ *
+ * 3) 조회 성능 보너스
+ *    - UNIQUE 인덱스가 자동 생성되어
+ *      existsByUserUserIdAndCouponEventCouponEventId 같은 조회 쿼리가
+ *      인덱스 스캔으로 빠르게 동작한다.
+ *
+ * PK는 user_coupon_id(대리 키)로 유지하여 조인 및 연관관계 처리 편의성을 확보하고,
+ * 비즈니스 제약은 UNIQUE 제약으로 분리 표현하는 구조이다.
+ */
 @Table(name = "user_coupons", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "coupon_event_id"})
 })

--- a/src/main/java/ccommit/stylehub/coupon/enums/CouponType.java
+++ b/src/main/java/ccommit/stylehub/coupon/enums/CouponType.java
@@ -1,0 +1,17 @@
+package ccommit.stylehub.coupon.enums;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/16
+ *
+ * <p>
+ * 쿠폰 이벤트의 발행 주체 타입을 정의한다.
+ * PLATFORM: 관리자가 발행한 플랫폼 전역 쿠폰 (store = null)
+ * STORE: 스토어가 발행한 개별 스토어 쿠폰 (store != null)
+ * </p>
+ */
+public enum CouponType {
+
+    PLATFORM,   // 관리자 발행 (플랫폼 전역)
+    STORE       // 스토어 발행 (개별 스토어)
+}

--- a/src/main/java/ccommit/stylehub/coupon/enums/DiscountType.java
+++ b/src/main/java/ccommit/stylehub/coupon/enums/DiscountType.java
@@ -1,18 +1,31 @@
 package ccommit.stylehub.coupon.enums;
 
-import lombok.Getter;
-
 /**
  * @author WonJin Bae
  * @created 2026/03/21 08:17
  * @modified 2026/03/21 08:17 by WonJin - refactor: bwj 패키지명 ccommit으로 변경
+ * @modified 2026/04/09 by WonJin - refactor: 전략 패턴 적용, 할인 계산 로직을 enum에 캡슐화
  *
  * <p>
- * 쿠폰의 할인 방식(FIXED 정액/RATE 정률)을 정의한다.
+ * 쿠폰의 할인 방식을 정의하고, 각 타입별 할인 금액 계산 로직을 캡슐화한다.
+ * 새로운 할인 유형 추가 시 enum 상수만 추가하면 된다.
  * </p>
  */
-
-@Getter
 public enum DiscountType {
-    FIXED, RATE
+
+    FIXED {
+        @Override
+        public int calculate(int orderAmount, int discountValue) {
+            return Math.min(discountValue, orderAmount);
+        }
+    },
+
+    RATE {
+        @Override
+        public int calculate(int orderAmount, int discountValue) {
+            return orderAmount * discountValue / 100;
+        }
+    };
+
+    public abstract int calculate(int orderAmount, int discountValue);
 }

--- a/src/main/java/ccommit/stylehub/coupon/repository/CouponEventRepository.java
+++ b/src/main/java/ccommit/stylehub/coupon/repository/CouponEventRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 /**
  * @author WonJin Bae
  * @created 2026/04/09
+ * @modified 2026/04/16 by WonJin - refactor: 활성 쿠폰 조회를 @Query로 전환, 파라미터 단일화 (now1/now2 → now)
  *
  * <p>
  * CouponEvent 엔티티의 데이터 접근을 담당한다.
@@ -28,6 +29,10 @@ public interface CouponEventRepository extends JpaRepository<CouponEvent, Long> 
 
     List<CouponEvent> findByStoreStoreId(Long storeId);
 
-    List<CouponEvent> findByActiveTrueAndStartedAtBeforeAndExpiredAtAfter(
-            LocalDateTime now1, LocalDateTime now2);
+    // 현재 시점 기준으로 활성 상태이며 진행 중인 쿠폰 이벤트를 조회한다.
+    @Query("SELECT ce FROM CouponEvent ce " +
+            "WHERE ce.active = true " +
+            "AND ce.startedAt < :now " +
+            "AND ce.expiredAt > :now")
+    List<CouponEvent> findActiveCouponEvents(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/ccommit/stylehub/coupon/repository/CouponEventRepository.java
+++ b/src/main/java/ccommit/stylehub/coupon/repository/CouponEventRepository.java
@@ -1,0 +1,33 @@
+package ccommit.stylehub.coupon.repository;
+
+import ccommit.stylehub.coupon.entity.CouponEvent;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/09
+ *
+ * <p>
+ * CouponEvent 엔티티의 데이터 접근을 담당한다.
+ * </p>
+ */
+public interface CouponEventRepository extends JpaRepository<CouponEvent, Long> {
+
+    // 비관적 락(SELECT FOR UPDATE)으로 쿠폰 이벤트를 조회한다. (선착순 발급 시 사용)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ce FROM CouponEvent ce WHERE ce.couponEventId = :couponEventId")
+    Optional<CouponEvent> findByIdWithLock(@Param("couponEventId") Long couponEventId);
+
+    List<CouponEvent> findByStoreStoreId(Long storeId);
+
+    List<CouponEvent> findByActiveTrueAndStartedAtBeforeAndExpiredAtAfter(
+            LocalDateTime now1, LocalDateTime now2);
+}

--- a/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
+++ b/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
@@ -145,9 +145,8 @@ public class CouponService {
      */
     @Transactional(readOnly = true)
     public List<CouponEventResponse> getActiveCouponEvents() {
-        LocalDateTime now = LocalDateTime.now();
         return couponEventRepository
-                .findByActiveTrueAndStartedAtBeforeAndExpiredAtAfter(now, now)
+                .findActiveCouponEvents(LocalDateTime.now())
                 .stream()
                 .map(CouponEventResponse::from)
                 .toList();

--- a/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
+++ b/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
@@ -1,0 +1,176 @@
+package ccommit.stylehub.coupon.service;
+
+import ccommit.stylehub.common.exception.BusinessException;
+import ccommit.stylehub.common.exception.ErrorCode;
+import ccommit.stylehub.coupon.dto.request.CouponEventCreateRequest;
+import ccommit.stylehub.coupon.dto.request.CouponEventUpdateRequest;
+import ccommit.stylehub.coupon.dto.response.CouponEventResponse;
+import ccommit.stylehub.coupon.dto.response.UserCouponResponse;
+import ccommit.stylehub.coupon.entity.CouponEvent;
+import ccommit.stylehub.coupon.entity.UserCoupon;
+import ccommit.stylehub.coupon.enums.DiscountType;
+import ccommit.stylehub.coupon.repository.CouponEventRepository;
+import ccommit.stylehub.coupon.repository.UserCouponRepository;
+import ccommit.stylehub.store.entity.Store;
+import ccommit.stylehub.store.service.StoreService;
+import ccommit.stylehub.user.entity.User;
+import ccommit.stylehub.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/09
+ *
+ * <p>
+ * 쿠폰 이벤트 생성과 선착순 쿠폰 발급을 담당한다.
+ * 선착순 발급은 비관적 락(SELECT FOR UPDATE)으로 수량 정합성을 보장한다.
+ * </p>
+ */
+// TODO: 성능 테스트 후 분산락 적용예정
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponEventRepository couponEventRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+    private final StoreService storeService;
+
+    /**
+     * 스토어 쿠폰 이벤트를 생성한다.
+     * 소유권 검증 후 이벤트를 DB에 저장한다.
+     */
+    @Transactional
+    public CouponEventResponse createStoreCouponEvent(Long userId, Long storeId,
+                                                      CouponEventCreateRequest request) {
+        Store store = storeService.findApprovedStoreByOwner(userId, storeId);
+        validateCouponEventRequest(request);
+
+        CouponEvent event = couponEventRepository.save(CouponEvent.create(
+                store, request.name(), request.discountType(), request.discountValue(),
+                request.minOrderAmount(), request.issueCount(), request.startedAt(), request.expiredAt()
+        ));
+
+        return CouponEventResponse.from(event);
+    }
+
+    /**
+     * 플랫폼(관리자) 쿠폰 이벤트를 생성한다.
+     */
+    @Transactional
+    public CouponEventResponse createPlatformCouponEvent(CouponEventCreateRequest request) {
+        validateCouponEventRequest(request);
+
+        CouponEvent event = couponEventRepository.save(CouponEvent.createPlatform(
+                request.name(), request.discountType(), request.discountValue(),
+                request.minOrderAmount(), request.issueCount(), request.startedAt(), request.expiredAt()
+        ));
+
+        return CouponEventResponse.from(event);
+    }
+
+    /**
+     * 선착순 쿠폰을 발급한다.
+     * 비관적 락(SELECT FOR UPDATE)으로 CouponEvent를 잠근 뒤 수량을 차감한다.
+     * DB UNIQUE 제약으로 중복 발급을 방지한다.
+     */
+    @Transactional
+    public void issueCoupon(Long userId, Long couponEventId) {
+        CouponEvent event = couponEventRepository.findByIdWithLock(couponEventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        validateCouponEvent(event);
+        checkDuplicateIssue(userId, couponEventId);
+
+        event.increaseIssuedCount();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        userCouponRepository.save(UserCoupon.create(user, event));
+    }
+
+    /**
+     * 쿠폰 이벤트를 수정한다. 이미 발급된 수량보다 적게 변경할 수 없다.
+     */
+    @Transactional
+    public CouponEventResponse updateCouponEvent(Long couponEventId, CouponEventUpdateRequest request) {
+        CouponEvent event = couponEventRepository.findById(couponEventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (request.startedAt().isAfter(request.expiredAt())) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_PERIOD);
+        }
+        if (request.issueCount() < event.getIssuedCount()) {
+            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
+        }
+
+        event.update(request.issueCount(), request.minOrderAmount(),
+                request.startedAt(), request.expiredAt());
+
+        return CouponEventResponse.from(event);
+    }
+
+    // 쿠폰 이벤트를 비활성화하여 발급을 중단한다.
+    @Transactional
+    public void deactivateCouponEvent(Long couponEventId) {
+        CouponEvent event = couponEventRepository.findById(couponEventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        event.deactivate();
+    }
+
+    private void checkDuplicateIssue(Long userId, Long couponEventId) {
+        if (userCouponRepository.existsByUserUserIdAndCouponEventCouponEventId(userId, couponEventId)) {
+            throw new BusinessException(ErrorCode.COUPON_ALREADY_ISSUED);
+        }
+    }
+
+    // 내가 보유한 쿠폰 목록을 조회한다.
+    @Transactional(readOnly = true)
+    public List<UserCouponResponse> getMyCoupons(Long userId) {
+        return userCouponRepository.findByUserIdWithCouponEvent(userId)
+                .stream()
+                .map(UserCouponResponse::from)
+                .toList();
+    }
+
+    /**
+     * 현재 발급 가능한 쿠폰 이벤트 목록을 조회한다.
+     */
+    @Transactional(readOnly = true)
+    public List<CouponEventResponse> getActiveCouponEvents() {
+        LocalDateTime now = LocalDateTime.now();
+        return couponEventRepository
+                .findByActiveTrueAndStartedAtBeforeAndExpiredAtAfter(now, now)
+                .stream()
+                .map(CouponEventResponse::from)
+                .toList();
+    }
+
+    private void validateCouponEvent(CouponEvent event) {
+        if (!event.getActive()) {
+            throw new BusinessException(ErrorCode.COUPON_NOT_ACTIVE);
+        }
+        if (event.isNotStarted()) {
+            throw new BusinessException(ErrorCode.COUPON_NOT_STARTED);
+        }
+        if (event.isExpired()) {
+            throw new BusinessException(ErrorCode.COUPON_EXPIRED);
+        }
+    }
+
+    private void validateCouponEventRequest(CouponEventCreateRequest request) {
+        if (request.startedAt().isAfter(request.expiredAt())) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_PERIOD);
+        }
+        if (request.discountType() == DiscountType.RATE && request.discountValue() > 100) {
+            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
+        }
+    }
+}

--- a/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
+++ b/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
@@ -8,9 +8,9 @@ import ccommit.stylehub.coupon.dto.response.CouponEventResponse;
 import ccommit.stylehub.coupon.dto.response.UserCouponResponse;
 import ccommit.stylehub.coupon.entity.CouponEvent;
 import ccommit.stylehub.coupon.entity.UserCoupon;
-import ccommit.stylehub.coupon.enums.DiscountType;
 import ccommit.stylehub.coupon.repository.CouponEventRepository;
 import ccommit.stylehub.coupon.repository.UserCouponRepository;
+import ccommit.stylehub.coupon.validator.CouponValidator;
 import ccommit.stylehub.store.entity.Store;
 import ccommit.stylehub.store.service.StoreService;
 import ccommit.stylehub.user.entity.User;
@@ -25,10 +25,12 @@ import java.util.List;
 /**
  * @author WonJin Bae
  * @created 2026/04/09
+ * @modified 2026/04/16 by WonJin - refactor: 검증 로직을 CouponValidator로 분리
  *
  * <p>
  * 쿠폰 이벤트 생성과 선착순 쿠폰 발급을 담당한다.
  * 선착순 발급은 비관적 락(SELECT FOR UPDATE)으로 수량 정합성을 보장한다.
+ * 검증은 CouponValidator, PG/스토어 조회는 StoreService에 위임한다.
  * </p>
  */
 // TODO: 성능 테스트 후 분산락 적용예정
@@ -40,6 +42,7 @@ public class CouponService {
     private final UserCouponRepository userCouponRepository;
     private final UserRepository userRepository;
     private final StoreService storeService;
+    private final CouponValidator couponValidator;
 
     /**
      * 스토어 쿠폰 이벤트를 생성한다.
@@ -49,7 +52,7 @@ public class CouponService {
     public CouponEventResponse createStoreCouponEvent(Long userId, Long storeId,
                                                       CouponEventCreateRequest request) {
         Store store = storeService.findApprovedStoreByOwner(userId, storeId);
-        validateCouponEventRequest(request);
+        couponValidator.validateCreate(request);
 
         CouponEvent event = couponEventRepository.save(CouponEvent.create(
                 store, request.name(), request.discountType(), request.discountValue(),
@@ -64,7 +67,7 @@ public class CouponService {
      */
     @Transactional
     public CouponEventResponse createPlatformCouponEvent(CouponEventCreateRequest request) {
-        validateCouponEventRequest(request);
+        couponValidator.validateCreate(request);
 
         CouponEvent event = couponEventRepository.save(CouponEvent.createPlatform(
                 request.name(), request.discountType(), request.discountValue(),
@@ -84,7 +87,7 @@ public class CouponService {
         CouponEvent event = couponEventRepository.findByIdWithLock(couponEventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
 
-        validateCouponEvent(event);
+        couponValidator.validateIssuable(event);
         checkDuplicateIssue(userId, couponEventId);
 
         event.increaseIssuedCount();
@@ -103,12 +106,7 @@ public class CouponService {
         CouponEvent event = couponEventRepository.findById(couponEventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
 
-        if (request.startedAt().isAfter(request.expiredAt())) {
-            throw new BusinessException(ErrorCode.INVALID_COUPON_PERIOD);
-        }
-        if (request.issueCount() < event.getIssuedCount()) {
-            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
-        }
+        couponValidator.validateUpdate(event, request);
 
         event.update(request.issueCount(), request.minOrderAmount(),
                 request.startedAt(), request.expiredAt());
@@ -152,24 +150,4 @@ public class CouponService {
                 .toList();
     }
 
-    private void validateCouponEvent(CouponEvent event) {
-        if (!event.getActive()) {
-            throw new BusinessException(ErrorCode.COUPON_NOT_ACTIVE);
-        }
-        if (event.isNotStarted()) {
-            throw new BusinessException(ErrorCode.COUPON_NOT_STARTED);
-        }
-        if (event.isExpired()) {
-            throw new BusinessException(ErrorCode.COUPON_EXPIRED);
-        }
-    }
-
-    private void validateCouponEventRequest(CouponEventCreateRequest request) {
-        if (request.startedAt().isAfter(request.expiredAt())) {
-            throw new BusinessException(ErrorCode.INVALID_COUPON_PERIOD);
-        }
-        if (request.discountType() == DiscountType.RATE && request.discountValue() > 100) {
-            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
-        }
-    }
 }

--- a/src/main/java/ccommit/stylehub/coupon/validator/CouponValidator.java
+++ b/src/main/java/ccommit/stylehub/coupon/validator/CouponValidator.java
@@ -1,0 +1,68 @@
+package ccommit.stylehub.coupon.validator;
+
+import ccommit.stylehub.common.exception.BusinessException;
+import ccommit.stylehub.common.exception.ErrorCode;
+import ccommit.stylehub.coupon.dto.request.CouponEventCreateRequest;
+import ccommit.stylehub.coupon.dto.request.CouponEventUpdateRequest;
+import ccommit.stylehub.coupon.entity.CouponEvent;
+import ccommit.stylehub.coupon.enums.DiscountType;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/16
+ *
+ * <p>
+ * 쿠폰 이벤트의 생성/수정/발급 시점별 검증 규칙을 담당한다.
+ * 기존 CouponService에 흩어져 있던 검증 로직을 통합하여 단일 책임을 갖도록 한다.
+ * </p>
+ */
+@Component
+public class CouponValidator {
+
+    /**
+     * 쿠폰 발급 시점 검증.
+     * - 비활성 상태가 아닐 것
+     * - 시작 전이 아닐 것
+     * - 만료되지 않았을 것
+     */
+    public void validateIssuable(CouponEvent event) {
+        if (!event.getActive()) {
+            throw new BusinessException(ErrorCode.COUPON_NOT_ACTIVE);
+        }
+        if (event.isNotStarted()) {
+            throw new BusinessException(ErrorCode.COUPON_NOT_STARTED);
+        }
+        if (event.isExpired()) {
+            throw new BusinessException(ErrorCode.COUPON_EXPIRED);
+        }
+    }
+
+    /**
+     * 쿠폰 이벤트 생성 시점 검증.
+     * - 유효기간이 올바를 것 (시작일 <= 만료일)
+     * - 할인 유형이 RATE인 경우 할인 값이 100% 이하일 것
+     */
+    public void validateCreate(CouponEventCreateRequest request) {
+        if (request.startedAt().isAfter(request.expiredAt())) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_PERIOD);
+        }
+        if (request.discountType() == DiscountType.RATE && request.discountValue() > 100) {
+            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
+        }
+    }
+
+    /**
+     * 쿠폰 이벤트 수정 시점 검증.
+     * - 유효기간이 올바를 것
+     * - 이미 발급된 수량보다 적은 수량으로 변경하지 않을 것
+     */
+    public void validateUpdate(CouponEvent event, CouponEventUpdateRequest request) {
+        if (request.startedAt().isAfter(request.expiredAt())) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_PERIOD);
+        }
+        if (request.issueCount() < event.getIssuedCount()) {
+            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
+        }
+    }
+}

--- a/src/main/java/ccommit/stylehub/order/dto/request/UpdateDeliveryStatusRequest.java
+++ b/src/main/java/ccommit/stylehub/order/dto/request/UpdateDeliveryStatusRequest.java
@@ -1,0 +1,20 @@
+package ccommit.stylehub.order.dto.request;
+
+import ccommit.stylehub.order.enums.OrderStatus;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/16
+ *
+ * <p>
+ * 배송 상태 변경 요청의 서비스 레이어 파라미터를 묶는 DTO이다.
+ * 컨트롤러에서 사용자/스토어/주문 식별자와 변경할 상태를 합쳐 서비스로 전달한다.
+ * </p>
+ */
+public record UpdateDeliveryStatusRequest(
+        Long userId,
+        Long storeId,
+        Long orderId,
+        OrderStatus newStatus
+) {
+}


### PR DESCRIPTION
 ## #️⃣Issue Number

  - #27 

  ## 📝 요약(Summary)
  - 선착순 쿠폰 발급 기능 구현 (비관적 락으로 수량 정합성 보장)                                                                                                                    
  - STORE 역할 사용자가 자기 스토어 쿠폰 이벤트 생성, ADMIN이 플랫폼 쿠폰 이벤트 생성
  - ADMIN이 쿠폰 이벤트 수정/비활성화 가능                                                                                                                                         
  - USER가 선착순으로 쿠폰 발급, 내 쿠폰 목록 조회                                                                                                                                 
  - 전략 패턴으로 할인 유형별(FIXED/RATE) 계산 로직을 enum에 캡슐화                                                                                                                
                                                                     


  ## 🛠️PR 유형
 어떤 변경 사항이 있나요?

  - [x] 새로운 기능 추가
  - [ ] 버그 수정
  - [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
  - [ ] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [ ] 테스트 추가, 테스트 리팩토링
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

---
  ## 주요 설계 결정
   1. 비관적 락(SELECT FOR UPDATE)으로 수량 정합성 보장

  - CouponEvent를 비관적 락으로 조회하여 동시 발급 시 수량 초과 방지                                                                                                               
  - 추후 분산 락 → Redis DECR 원자적 연산으로 단계별 성능 개선 예정
  - 각 단계별 TPS를 비교하여 대용량 트래픽 최적화 근거를 마련할 계획                                                                                                               
                                                                                                                                                                                   
  2. 전략 패턴으로 할인 계산 로직 캡슐화                                                                                                                                           
                                                                                                                                                                                   
  - DiscountType enum에 abstract calculate() 메서드를 선언하여 FIXED/RATE 각각 구현                                                                                                
  - 서비스에서 if/else 분기 없이 coupon.calculateDiscount(orderAmount) 한 줄로 계산
  - 새 할인 유형 추가 시 enum 상수만 추가하면 기존 코드 수정 없이 동작 (OCP)                                                                                                       
  - 결제 도메인의 PaymentClient 인터페이스 전략과 달리, 전략 수가 적고 DB 저장이 필요하여 enum 방식 선택                                                                           
                                                                                                                                                                                   
  3. CouponEvent.createPlatform() 정적 팩토리 메서드 분리                                                                                                                          
                                                                                                                                                                                   
  - 플랫폼 쿠폰은 store = null인데, create(null, ...) 호출 시 의도가 드러나지 않음                                                                                                 
  - User.create()와 User.createOAuth()를 분리한 기존 패턴과 동일하게 적용
                                                                                                                                                                                   
  4. 중복 발급 방지 2단계                                   
                                                                                                                                                                                   
  - 1차: DB 쿼리(existsByUserUserIdAndCouponEventCouponEventId)로 중복 체크                                                                                                        
  - 2차: user_coupons 테이블의 UNIQUE 제약(user_id + coupon_event_id)으로 최종 방어
                                                                                                                                                                                   
  5. 쿠폰 이벤트 비활성화                                   
                                                                                                                                                                                   
  - 잘못된 쿠폰 생성 시 만료일까지 기다리지 않고 즉시 발급을 중단할 수 있도록 deactivate API 추가                                                                                  
  - 기존 validateCouponEvent()에서 active == false 체크가 이미 구현되어 있어 API만 추가
                                                                                            

                                                                                                           