### PR TITLE
 refactor: 헥사고날 아키텍쳐의 port 인터페이스 도입

### DIFF
--- a/src/main/java/ccommit/stylehub/coupon/controller/CouponController.java
+++ b/src/main/java/ccommit/stylehub/coupon/controller/CouponController.java
@@ -6,7 +6,7 @@ import ccommit.stylehub.coupon.dto.request.CouponEventCreateRequest;
 import ccommit.stylehub.coupon.dto.request.CouponEventUpdateRequest;
 import ccommit.stylehub.coupon.dto.response.CouponEventResponse;
 import ccommit.stylehub.coupon.dto.response.UserCouponResponse;
-import ccommit.stylehub.coupon.service.CouponService;
+import ccommit.stylehub.coupon.service.CouponApplicationService;
 import ccommit.stylehub.user.enums.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -34,7 +34,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CouponController {
 
-    private final CouponService couponService;
+    private final CouponApplicationService couponApplicationService;
 
     // STORE: 스토어 쿠폰 이벤트 생성
     @PostMapping("/stores/{storeId}/coupon-events")
@@ -45,7 +45,7 @@ public class CouponController {
             HttpServletRequest httpRequest) {
         Long userId = SessionUtils.getUserId(httpRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(couponService.createStoreCouponEvent(userId, storeId, request));
+                .body(couponApplicationService.createStoreCouponEvent(userId, storeId, request));
     }
 
     // ADMIN: 플랫폼 쿠폰 이벤트 생성
@@ -54,7 +54,7 @@ public class CouponController {
     public ResponseEntity<CouponEventResponse> createPlatformCouponEvent(
             @Valid @RequestBody CouponEventCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(couponService.createPlatformCouponEvent(request));
+                .body(couponApplicationService.createPlatformCouponEvent(request));
     }
 
     // ADMIN: 쿠폰 이벤트 수정
@@ -63,14 +63,14 @@ public class CouponController {
     public ResponseEntity<CouponEventResponse> updateCouponEvent(
             @PathVariable Long couponEventId,
             @Valid @RequestBody CouponEventUpdateRequest request) {
-        return ResponseEntity.ok(couponService.updateCouponEvent(couponEventId, request));
+        return ResponseEntity.ok(couponApplicationService.updateCouponEvent(couponEventId, request));
     }
 
     // ADMIN: 쿠폰 이벤트 비활성화
     @PatchMapping("/admin/coupon-events/{couponEventId}/deactivate")
     @RequiredRole(UserRole.ADMIN)
     public ResponseEntity<Void> deactivateCouponEvent(@PathVariable Long couponEventId) {
-        couponService.deactivateCouponEvent(couponEventId);
+        couponApplicationService.deactivateCouponEvent(couponEventId);
         return ResponseEntity.ok().build();
     }
 
@@ -79,7 +79,7 @@ public class CouponController {
     @RequiredRole(UserRole.USER)
     public ResponseEntity<List<UserCouponResponse>> getMyCoupons(HttpServletRequest httpRequest) {
         Long userId = SessionUtils.getUserId(httpRequest);
-        return ResponseEntity.ok(couponService.getMyCoupons(userId));
+        return ResponseEntity.ok(couponApplicationService.getMyCoupons(userId));
     }
 
     // USER: 선착순 쿠폰 발급
@@ -89,13 +89,13 @@ public class CouponController {
             @PathVariable Long couponEventId,
             HttpServletRequest httpRequest) {
         Long userId = SessionUtils.getUserId(httpRequest);
-        couponService.issueCoupon(userId, couponEventId);
+        couponApplicationService.issueCoupon(userId, couponEventId);
         return ResponseEntity.ok().build();
     }
 
     // 활성 쿠폰 이벤트 목록 조회 (공개)
     @GetMapping("/coupon-events")
     public ResponseEntity<List<CouponEventResponse>> getActiveCouponEvents() {
-        return ResponseEntity.ok(couponService.getActiveCouponEvents());
+        return ResponseEntity.ok(couponApplicationService.getActiveCouponEvents());
     }
 }

--- a/src/main/java/ccommit/stylehub/coupon/controller/CouponController.java
+++ b/src/main/java/ccommit/stylehub/coupon/controller/CouponController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -32,7 +31,6 @@ import java.util.List;
  * </p>
  */
 @RestController
-@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class CouponController {
 

--- a/src/main/java/ccommit/stylehub/coupon/service/CouponApplicationService.java
+++ b/src/main/java/ccommit/stylehub/coupon/service/CouponApplicationService.java
@@ -1,0 +1,69 @@
+package ccommit.stylehub.coupon.service;
+
+import ccommit.stylehub.coupon.dto.request.CouponEventCreateRequest;
+import ccommit.stylehub.coupon.dto.request.CouponEventUpdateRequest;
+import ccommit.stylehub.coupon.dto.response.CouponEventResponse;
+import ccommit.stylehub.coupon.dto.response.UserCouponResponse;
+import ccommit.stylehub.user.entity.User;
+import ccommit.stylehub.user.port.UserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * Coupon 유스케이스를 오케스트레이션하는 Application 계층 서비스이다.
+ * 스토어 소유권 검증과 User 조회(UserPort)를 담당하고, 쿠폰 도메인 로직은 CouponService에 위임한다.
+ * 권한 검증은 Application 관심사이므로 Domain 계층(CouponService)에서 분리해 여기서 처리한다.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class CouponApplicationService {
+
+    private final UserPort userPort;
+    private final CouponService couponService;
+
+    @Transactional
+    public CouponEventResponse createStoreCouponEvent(Long userId, Long storeId,
+                                                      CouponEventCreateRequest request) {
+        User storeOwner = userPort.findApprovedStoreByOwner(userId, storeId);
+        return couponService.createStoreCouponEvent(storeOwner, request);
+    }
+
+    @Transactional
+    public CouponEventResponse createPlatformCouponEvent(CouponEventCreateRequest request) {
+        return couponService.createPlatformCouponEvent(request);
+    }
+
+    @Transactional
+    public CouponEventResponse updateCouponEvent(Long couponEventId, CouponEventUpdateRequest request) {
+        return couponService.updateCouponEvent(couponEventId, request);
+    }
+
+    @Transactional
+    public void deactivateCouponEvent(Long couponEventId) {
+        couponService.deactivateCouponEvent(couponEventId);
+    }
+
+    @Transactional
+    public void issueCoupon(Long userId, Long couponEventId) {
+        User user = userPort.findUserById(userId);
+        couponService.issueCoupon(user, couponEventId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserCouponResponse> getMyCoupons(Long userId) {
+        return couponService.getMyCoupons(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CouponEventResponse> getActiveCouponEvents() {
+        return couponService.getActiveCouponEvents();
+    }
+}

--- a/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
+++ b/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
@@ -11,7 +11,6 @@ import ccommit.stylehub.coupon.entity.UserCoupon;
 import ccommit.stylehub.coupon.repository.CouponEventRepository;
 import ccommit.stylehub.coupon.repository.UserCouponRepository;
 import ccommit.stylehub.coupon.validator.CouponValidator;
-import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,11 +23,12 @@ import java.util.List;
  * @author WonJin Bae
  * @created 2026/04/09
  * @modified 2026/04/16 by WonJin - refactor: 검증 로직을 CouponValidator로 분리
+ * @modified 2026/04/22 by WonJin - refactor: UserPort 의존 제거, 권한 검증·User 조회는 CouponApplicationService로 이관 (도메인 서비스는 자기 도메인만 알도록 분리)
  *
  * <p>
- * 쿠폰 이벤트 생성과 선착순 쿠폰 발급을 담당한다.
+ * 쿠폰 이벤트 생성과 선착순 쿠폰 발급을 담당하는 순수 도메인 서비스이다.
  * 선착순 발급은 비관적 락(SELECT FOR UPDATE)으로 수량 정합성을 보장한다.
- * 검증은 CouponValidator, PG/스토어 조회는 StoreService에 위임한다.
+ * 스토어 소유권 검증, User 조회 같은 Application 관심사는 CouponApplicationService에서 처리한다.
  * </p>
  */
 // TODO: 성능 테스트 후 분산락 적용예정
@@ -38,17 +38,13 @@ public class CouponService {
 
     private final CouponEventRepository couponEventRepository;
     private final UserCouponRepository userCouponRepository;
-    private final UserPort userPort;
     private final CouponValidator couponValidator;
 
     /**
-     * 스토어 쿠폰 이벤트를 생성한다.
-     * 소유권 검증 후 이벤트를 DB에 저장한다.
+     * 스토어 쿠폰 이벤트를 생성한다. 스토어 소유권 검증은 상위 계층에서 수행된 상태라고 가정한다.
      */
     @Transactional
-    public CouponEventResponse createStoreCouponEvent(Long userId, Long storeId,
-                                                      CouponEventCreateRequest request) {
-        User storeOwner = userPort.findApprovedStoreByOwner(userId, storeId);
+    public CouponEventResponse createStoreCouponEvent(User storeOwner, CouponEventCreateRequest request) {
         couponValidator.validateCreate(request);
 
         CouponEvent event = couponEventRepository.save(CouponEvent.create(
@@ -80,16 +76,14 @@ public class CouponService {
      * DB UNIQUE 제약으로 중복 발급을 방지한다.
      */
     @Transactional
-    public void issueCoupon(Long userId, Long couponEventId) {
+    public void issueCoupon(User user, Long couponEventId) {
         CouponEvent event = couponEventRepository.findByIdWithLock(couponEventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
 
         couponValidator.validateIssuable(event);
-        checkDuplicateIssue(userId, couponEventId);
+        checkDuplicateIssue(user.getUserId(), couponEventId);
 
         event.increaseIssuedCount();
-
-        User user = userPort.findUserById(userId);
 
         userCouponRepository.save(UserCoupon.create(user, event));
     }

--- a/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
+++ b/src/main/java/ccommit/stylehub/coupon/service/CouponService.java
@@ -11,8 +11,8 @@ import ccommit.stylehub.coupon.entity.UserCoupon;
 import ccommit.stylehub.coupon.repository.CouponEventRepository;
 import ccommit.stylehub.coupon.repository.UserCouponRepository;
 import ccommit.stylehub.coupon.validator.CouponValidator;
+import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.user.entity.User;
-import ccommit.stylehub.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +38,7 @@ public class CouponService {
 
     private final CouponEventRepository couponEventRepository;
     private final UserCouponRepository userCouponRepository;
-    private final UserService userService;
+    private final UserPort userPort;
     private final CouponValidator couponValidator;
 
     /**
@@ -48,7 +48,7 @@ public class CouponService {
     @Transactional
     public CouponEventResponse createStoreCouponEvent(Long userId, Long storeId,
                                                       CouponEventCreateRequest request) {
-        User storeOwner = userService.findApprovedStoreByOwner(userId, storeId);
+        User storeOwner = userPort.findApprovedStoreByOwner(userId, storeId);
         couponValidator.validateCreate(request);
 
         CouponEvent event = couponEventRepository.save(CouponEvent.create(
@@ -89,7 +89,7 @@ public class CouponService {
 
         event.increaseIssuedCount();
 
-        User user = userService.findUserById(userId);
+        User user = userPort.findUserById(userId);
 
         userCouponRepository.save(UserCoupon.create(user, event));
     }

--- a/src/main/java/ccommit/stylehub/order/entity/Order.java
+++ b/src/main/java/ccommit/stylehub/order/entity/Order.java
@@ -34,6 +34,7 @@ import java.util.UUID;
  * @modified 2026/03/27 by WonJin - feat: 주문 상태 변경 메서드 추가, 와일드카드 import 수정
  * @modified 2026/04/02 by WonJin - feat: 배송 상태 전이 메서드 추가
  * @modified 2026/04/16 by WonJin - refactor: DeliveryStatus를 OrderStatus로 통합
+ * @modified 2026/04/22 by WonJin - refactor: cancel/cancelPaid 통합 (내부 상태 PENDING/PAID 모두 허용) — 호출자가 상태를 알 필요 없게 함
  *
  * <p>
  * 사용자의 주문 정보를 관리한다.
@@ -98,8 +99,9 @@ public class Order extends BaseEntity {
         return totalAmount - this.discountAmount - this.usedPoint;
     }
 
+    // 주문 취소 — PENDING(결제 전) 또는 PAID(결제 완료) 상태에서만 전환 가능
     public void cancel() {
-        if (this.orderStatus != OrderStatus.PENDING) {
+        if (this.orderStatus != OrderStatus.PENDING && this.orderStatus != OrderStatus.PAID) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.orderStatus = OrderStatus.CANCELLED;
@@ -114,20 +116,12 @@ public class Order extends BaseEntity {
     public void updateOrderStatus(OrderStatus newStatus) {
         this.orderStatus = newStatus;
     }
-  
+
     // 결제 완료 처리 — PENDING → PAID + 배송 준비(PREPARING) 자동 설정
     public void markPaid() {
         if (this.orderStatus != OrderStatus.PENDING) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.orderStatus = OrderStatus.PAID;
-    }
-
-    // 결제 완료된 주문 취소 — PAID 상태에서만 전환 가능
-    public void cancelPaid() {
-        if (this.orderStatus != OrderStatus.PAID) {
-            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
-        }
-        this.orderStatus = OrderStatus.CANCELLED;
     }
 }

--- a/src/main/java/ccommit/stylehub/order/event/OrderEventListener.java
+++ b/src/main/java/ccommit/stylehub/order/event/OrderEventListener.java
@@ -1,0 +1,58 @@
+package ccommit.stylehub.order.event;
+
+import ccommit.stylehub.order.scheduler.OrderPaymentTimeout;
+import ccommit.stylehub.order.service.OrderService;
+import ccommit.stylehub.payment.event.PaymentApprovedEvent;
+import ccommit.stylehub.payment.event.PaymentFailedEvent;
+import ccommit.stylehub.payment.event.PaymentFullyCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * Order 도메인과 Payment 도메인의 이벤트를 수신해 Order 측 후속 작업을 수행한다.
+ *
+ * Redis 타임아웃 등록/제거는 AFTER_COMMIT 시점에만 수행해 트랜잭션 롤백 시 Redis와 DB 상태가 어긋나는 것을 막는다.
+ * 주문 상태 전이(취소 등)는 동기 리스너로 처리해 Payment 트랜잭션에 참여하여 원자성을 보장한다.
+ *
+ * OrderService가 PaymentService를 직접 주입하지 않도록 중간에서 매개해 순환 의존성을 제거한다.
+ * </p>
+ */
+@Component
+@RequiredArgsConstructor
+public class OrderEventListener {
+
+    private final OrderService orderService;
+    private final OrderPaymentTimeout orderPaymentTimeout;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onOrderPlaced(OrderPlacedEvent event) {
+        orderPaymentTimeout.registerTimeout(event.orderId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPaymentApproved(PaymentApprovedEvent event) {
+        orderPaymentTimeout.removeTimeout(event.orderId());
+    }
+
+    @EventListener
+    public void onPaymentFailed(PaymentFailedEvent event) {
+        orderService.cancelOrder(event.orderId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPaymentFailedAfterCommit(PaymentFailedEvent event) {
+        orderPaymentTimeout.removeTimeout(event.orderId());
+    }
+
+    @EventListener
+    public void onPaymentFullyCanceled(PaymentFullyCanceledEvent event) {
+        orderService.cancelOrder(event.orderId());
+    }
+}

--- a/src/main/java/ccommit/stylehub/order/event/OrderPlacedEvent.java
+++ b/src/main/java/ccommit/stylehub/order/event/OrderPlacedEvent.java
@@ -1,0 +1,15 @@
+package ccommit.stylehub.order.event;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ * @modified 2026/04/22 by WonJin - refactor: Order 엔티티 직접 전달 제거, primitives로 변경 (도메인 경계 누수 해소)
+ *
+ * <p>
+ * 주문 생성이 완료된 시점에 발행되는 도메인 이벤트.
+ * 동기 리스너는 Payment READY 엔티티를 생성하고, AFTER_COMMIT 리스너는 Redis 결제 타임아웃을 등록한다.
+ * Order/Payment 도메인 간 엔티티 직접 의존을 막기 위해 primitive 값만 전달한다.
+ * </p>
+ */
+public record OrderPlacedEvent(Long orderId, int totalAmount, int finalAmount) {
+}

--- a/src/main/java/ccommit/stylehub/order/port/OrderPort.java
+++ b/src/main/java/ccommit/stylehub/order/port/OrderPort.java
@@ -3,17 +3,17 @@ package ccommit.stylehub.order.port;
 /**
  * @author WonJin Bae
  * @created 2026/04/20
+ * @modified 2026/04/22 by WonJin - refactor: cancelPaidOrder 제거 — 내부 상태(PENDING/PAID)가 포트로 누수되지 않도록 cancelOrder로 통합
  *
  * <p>
  * Order 도메인이 외부에 제공하는 포트 인터페이스이다.
  * 주문 취소, 결제 타임아웃 제거를 제공한다.
+ * 이벤트 기반 리팩터링 이후 현재는 구현체가 없고 호출부도 이벤트로 통합되어 고아 상태이며, 후속 PR에서 제거 예정이다.
  * </p>
  */
 public interface OrderPort {
 
     void cancelOrder(Long orderId);
-
-    void cancelPaidOrder(Long orderId);
 
     void removeTimeout(Long orderId);
 }

--- a/src/main/java/ccommit/stylehub/order/port/OrderPort.java
+++ b/src/main/java/ccommit/stylehub/order/port/OrderPort.java
@@ -1,0 +1,19 @@
+package ccommit.stylehub.order.port;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/20
+ *
+ * <p>
+ * Order 도메인이 외부에 제공하는 포트 인터페이스이다.
+ * 주문 취소, 결제 타임아웃 제거를 제공한다.
+ * </p>
+ */
+public interface OrderPort {
+
+    void cancelOrder(Long orderId);
+
+    void cancelPaidOrder(Long orderId);
+
+    void removeTimeout(Long orderId);
+}

--- a/src/main/java/ccommit/stylehub/order/service/OrderService.java
+++ b/src/main/java/ccommit/stylehub/order/service/OrderService.java
@@ -1,44 +1,37 @@
 package ccommit.stylehub.order.service;
 
 import ccommit.stylehub.common.aop.ExecutionTimeCheck;
+import ccommit.stylehub.common.dto.CursorResponse;
 import ccommit.stylehub.common.exception.BusinessException;
 import ccommit.stylehub.common.exception.ErrorCode;
+import ccommit.stylehub.coupon.entity.UserCoupon;
 import ccommit.stylehub.order.dto.request.OrderCreateRequest;
-import ccommit.stylehub.order.dto.request.OrderItemRequest;
-import ccommit.stylehub.order.dto.request.UpdateDeliveryStatusRequest;
-import ccommit.stylehub.order.validator.DeliveryValidator;
-import ccommit.stylehub.order.dto.response.OrderCursorResponse;
-import ccommit.stylehub.order.dto.response.OrderItemResponse;
 import ccommit.stylehub.order.dto.request.OrderDetailRequest;
-import ccommit.stylehub.common.dto.CursorResponse;
+import ccommit.stylehub.order.dto.request.UpdateDeliveryStatusRequest;
 import ccommit.stylehub.order.dto.response.OrderDetailResponse;
 import ccommit.stylehub.order.dto.response.OrderListResponse;
 import ccommit.stylehub.order.dto.response.OrderResponse;
 import ccommit.stylehub.order.dto.response.OrderTotalAmountDto;
 import ccommit.stylehub.order.entity.Order;
 import ccommit.stylehub.order.entity.OrderDetail;
+import ccommit.stylehub.order.port.OrderPort;
+import ccommit.stylehub.payment.port.PaymentPort;
+import ccommit.stylehub.product.port.ProductPort;
+import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.order.repository.OrderDetailRepository;
 import ccommit.stylehub.order.repository.OrderQueryRepository;
 import ccommit.stylehub.order.repository.OrderRepository;
 import ccommit.stylehub.order.scheduler.OrderPaymentTimeout;
-import ccommit.stylehub.coupon.entity.UserCoupon;
-import ccommit.stylehub.payment.entity.Payment;
-import ccommit.stylehub.payment.repository.PaymentRepository;
+import ccommit.stylehub.order.validator.DeliveryValidator;
 import ccommit.stylehub.product.entity.ProductOption;
-import ccommit.stylehub.product.service.ProductService;
 import ccommit.stylehub.user.entity.Address;
-import ccommit.stylehub.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * @author WonJin Bae
@@ -57,7 +50,7 @@ import java.util.TreeMap;
  */
 @Service
 @RequiredArgsConstructor
-public class OrderService {
+public class OrderService implements OrderPort {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 100;
@@ -66,10 +59,10 @@ public class OrderService {
     private final OrderDetailRepository orderDetailRepository;
     private final OrderQueryRepository orderQueryRepository;
     private final DeliveryValidator deliveryValidator;
-    private final PaymentRepository paymentRepository;
     private final OrderPaymentTimeout orderPaymentTimeout;
-    private final UserService userService;
-    private final ProductService productService;
+    private final UserPort userPort;
+    private final ProductPort productPort;
+    private final PaymentPort paymentPort;
 
     /**
      * 주문을 접수한다.
@@ -81,7 +74,7 @@ public class OrderService {
     @ExecutionTimeCheck(threshold = 3000)
     @Transactional
     public OrderResponse placeOrder(Long userId, OrderCreateRequest request) {
-        Address address = userService.findAddressByOwner(userId, request.addressId());
+        Address address = userPort.findAddressByOwner(userId, request.addressId());
 
         // TODO: 쿠폰 유효성 검증 + 할인 금액 계산
         // TODO: 포인트 잔액 확인 + 차감
@@ -97,10 +90,7 @@ public class OrderService {
                 .sum();
         int finalAmount = savedOrder.calculateFinalAmount(totalAmount);
 
-        paymentRepository.save(Payment.create(
-                savedOrder, "", "주문 결제",
-                finalAmount, totalAmount, finalAmount
-        ));
+        paymentPort.createReady(savedOrder, totalAmount, finalAmount);
 
         registerTimeoutAfterCommit(savedOrder.getOrderId());
 
@@ -120,6 +110,7 @@ public class OrderService {
      * PENDING 상태인 주문을 취소하고 재고를 복구한다.
      * 상태 검증(cancel)을 먼저 수행하여 PENDING이 아닌 주문의 재고가 변경되는 것을 방지한다.
      */
+    @Override
     @Transactional
     public void cancelOrder(Long orderId) {
         Order order = orderRepository.findByIdWithLock(orderId)
@@ -129,13 +120,18 @@ public class OrderService {
         restoreStock(orderId);
     }
 
-    // 결제 취소에 의한 주문 취소 + 재고 복구 — PAID 상태에서만 호출
+    @Override
     public void cancelPaidOrder(Long orderId) {
         Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         order.cancelPaid();
         restoreStock(orderId);
+    }
+
+    @Override
+    public void removeTimeout(Long orderId) {
+        orderPaymentTimeout.removeTimeout(orderId);
     }
 
     private void restoreStock(Long orderId) {
@@ -147,7 +143,7 @@ public class OrderService {
                 b.getProductOption().getProductOptionId()));
 
         for (OrderDetail detail : details) {
-            productService.increaseStock(
+            productPort.increaseStock(
                     detail.getProductOption().getProductOptionId(),
                     detail.getQuantity()
             );
@@ -222,7 +218,7 @@ public class OrderService {
 
         List<OrderDetail> details = new ArrayList<>(merged.size());
         for (OrderDetailRequest request : merged) {
-            ProductOption option = productService.decreaseStockWithLock(
+            ProductOption option = productPort.decreaseStockWithLock(
                     request.productOptionId(), request.quantity()
             );
 

--- a/src/main/java/ccommit/stylehub/order/service/OrderService.java
+++ b/src/main/java/ccommit/stylehub/order/service/OrderService.java
@@ -14,24 +14,25 @@ import ccommit.stylehub.order.dto.response.OrderResponse;
 import ccommit.stylehub.order.dto.response.OrderTotalAmountDto;
 import ccommit.stylehub.order.entity.Order;
 import ccommit.stylehub.order.entity.OrderDetail;
-import ccommit.stylehub.order.port.OrderPort;
-import ccommit.stylehub.payment.port.PaymentPort;
+import ccommit.stylehub.order.event.OrderPlacedEvent;
 import ccommit.stylehub.product.port.ProductPort;
 import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.order.repository.OrderDetailRepository;
 import ccommit.stylehub.order.repository.OrderQueryRepository;
 import ccommit.stylehub.order.repository.OrderRepository;
-import ccommit.stylehub.order.scheduler.OrderPaymentTimeout;
 import ccommit.stylehub.order.validator.DeliveryValidator;
 import ccommit.stylehub.product.entity.ProductOption;
 import ccommit.stylehub.user.entity.Address;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * @author WonJin Bae
@@ -42,15 +43,17 @@ import java.util.*;
  * @modified 2026/04/16 by WonJin - refactor: DeliveryStatus를 OrderStatus로 통합
  * @modified 2026/04/08 by WonJin - refactor: OrderItem → OrderDetail 변경
  * @modified 2026/04/08 by WonJin - refactor: 이벤트 발행 제거, Payment 직접 생성 + TransactionSynchronization으로 Redis 타임아웃 등록
+ * @modified 2026/04/22 by WonJin - refactor: PaymentPort/OrderPaymentTimeout 직접 의존 제거, OrderPlacedEvent 발행으로 전환 (순환 참조 해소)
  *
  * <p>
  * 주문 생성, 취소, 배송 상태 관리, 조회를 담당한다.
  * 주문/결제 API는 ApiLoggingAspect에 의해 요청/응답이 자동 로깅된다.
+ * Payment 도메인과는 ApplicationEventPublisher를 통해서만 통신해 순환 의존성을 제거했다.
  * </p>
  */
 @Service
 @RequiredArgsConstructor
-public class OrderService implements OrderPort {
+public class OrderService {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 100;
@@ -59,10 +62,9 @@ public class OrderService implements OrderPort {
     private final OrderDetailRepository orderDetailRepository;
     private final OrderQueryRepository orderQueryRepository;
     private final DeliveryValidator deliveryValidator;
-    private final OrderPaymentTimeout orderPaymentTimeout;
     private final UserPort userPort;
     private final ProductPort productPort;
-    private final PaymentPort paymentPort;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 주문을 접수한다.
@@ -90,27 +92,15 @@ public class OrderService implements OrderPort {
                 .sum();
         int finalAmount = savedOrder.calculateFinalAmount(totalAmount);
 
-        paymentPort.createReady(savedOrder, totalAmount, finalAmount);
-
-        registerTimeoutAfterCommit(savedOrder.getOrderId());
+        eventPublisher.publishEvent(new OrderPlacedEvent(savedOrder.getOrderId(), totalAmount, finalAmount));
 
         return buildOrderResponse(savedOrder, savedDetails);
-    }
-
-    private void registerTimeoutAfterCommit(Long orderId) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                orderPaymentTimeout.registerTimeout(orderId);
-            }
-        });
     }
 
     /**
      * PENDING 상태인 주문을 취소하고 재고를 복구한다.
      * 상태 검증(cancel)을 먼저 수행하여 PENDING이 아닌 주문의 재고가 변경되는 것을 방지한다.
      */
-    @Override
     @Transactional
     public void cancelOrder(Long orderId) {
         Order order = orderRepository.findByIdWithLock(orderId)
@@ -120,18 +110,13 @@ public class OrderService implements OrderPort {
         restoreStock(orderId);
     }
 
-    @Override
+    @Transactional
     public void cancelPaidOrder(Long orderId) {
         Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         order.cancelPaid();
         restoreStock(orderId);
-    }
-
-    @Override
-    public void removeTimeout(Long orderId) {
-        orderPaymentTimeout.removeTimeout(orderId);
     }
 
     private void restoreStock(Long orderId) {

--- a/src/main/java/ccommit/stylehub/order/service/OrderService.java
+++ b/src/main/java/ccommit/stylehub/order/service/OrderService.java
@@ -44,6 +44,7 @@ import java.util.TreeMap;
  * @modified 2026/04/08 by WonJin - refactor: OrderItem → OrderDetail 변경
  * @modified 2026/04/08 by WonJin - refactor: 이벤트 발행 제거, Payment 직접 생성 + TransactionSynchronization으로 Redis 타임아웃 등록
  * @modified 2026/04/22 by WonJin - refactor: PaymentPort/OrderPaymentTimeout 직접 의존 제거, OrderPlacedEvent 발행으로 전환 (순환 참조 해소)
+ * @modified 2026/04/22 by WonJin - refactor: cancelOrder/cancelPaidOrder 단일화 (Order 내부 상태 누수 제거)
  *
  * <p>
  * 주문 생성, 취소, 배송 상태 관리, 조회를 담당한다.
@@ -98,8 +99,9 @@ public class OrderService {
     }
 
     /**
-     * PENDING 상태인 주문을 취소하고 재고를 복구한다.
-     * 상태 검증(cancel)을 먼저 수행하여 PENDING이 아닌 주문의 재고가 변경되는 것을 방지한다.
+     * 주문을 취소하고 재고를 복구한다.
+     * PENDING/PAID 상태 모두 허용되며, 상태 검증은 Order.cancel() 내부에서 수행한다.
+     * 호출자는 주문 상태를 몰라도 되도록 단일 메서드로 통합됐다.
      */
     @Transactional
     public void cancelOrder(Long orderId) {
@@ -107,15 +109,6 @@ public class OrderService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         order.cancel();
-        restoreStock(orderId);
-    }
-
-    @Transactional
-    public void cancelPaidOrder(Long orderId) {
-        Order order = orderRepository.findByIdWithLock(orderId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-
-        order.cancelPaid();
         restoreStock(orderId);
     }
 

--- a/src/main/java/ccommit/stylehub/order/validator/DeliveryValidator.java
+++ b/src/main/java/ccommit/stylehub/order/validator/DeliveryValidator.java
@@ -39,7 +39,7 @@ public class DeliveryValidator {
      * 검증 순서: 스토어 소유권 → 주문-스토어 매칭 → 상태 전이 규칙
      */
     public void validate(UpdateDeliveryStatusRequest request, Order order) {
-        userPort.findApprovedStoreByOwner(request.userId(), request.storeId());
+        userPort.validateApprovedStoreOwner(request.userId(), request.storeId());
         validateStoreOrder(request.storeId(), request.orderId());
         validateTransition(order.getOrderStatus(), request.newStatus());
     }

--- a/src/main/java/ccommit/stylehub/order/validator/DeliveryValidator.java
+++ b/src/main/java/ccommit/stylehub/order/validator/DeliveryValidator.java
@@ -7,7 +7,7 @@ import ccommit.stylehub.order.entity.Order;
 import ccommit.stylehub.order.entity.OrderItem;
 import ccommit.stylehub.order.enums.OrderStatus;
 import ccommit.stylehub.order.repository.OrderItemRepository;
-import ccommit.stylehub.user.service.UserService;
+import ccommit.stylehub.user.port.UserPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -31,7 +31,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DeliveryValidator {
 
-    private final UserService userService;
+    private final UserPort userPort;
     private final OrderItemRepository orderItemRepository;
 
     /**
@@ -39,7 +39,7 @@ public class DeliveryValidator {
      * 검증 순서: 스토어 소유권 → 주문-스토어 매칭 → 상태 전이 규칙
      */
     public void validate(UpdateDeliveryStatusRequest request, Order order) {
-        userService.validateApprovedStoreOwner(request.userId(), request.storeId());
+        userPort.findApprovedStoreByOwner(request.userId(), request.storeId());
         validateStoreOrder(request.storeId(), request.orderId());
         validateTransition(order.getOrderStatus(), request.newStatus());
     }

--- a/src/main/java/ccommit/stylehub/payment/event/PaymentApprovedEvent.java
+++ b/src/main/java/ccommit/stylehub/payment/event/PaymentApprovedEvent.java
@@ -1,0 +1,13 @@
+package ccommit.stylehub.payment.event;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * 결제 승인 성공 시 발행되는 도메인 이벤트.
+ * Order 도메인의 AFTER_COMMIT 리스너에서 Redis 결제 타임아웃을 제거한다.
+ * </p>
+ */
+public record PaymentApprovedEvent(Long orderId) {
+}

--- a/src/main/java/ccommit/stylehub/payment/event/PaymentEventListener.java
+++ b/src/main/java/ccommit/stylehub/payment/event/PaymentEventListener.java
@@ -1,0 +1,29 @@
+package ccommit.stylehub.payment.event;
+
+import ccommit.stylehub.order.event.OrderPlacedEvent;
+import ccommit.stylehub.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * Order 도메인이 발행한 이벤트를 수신해 Payment 도메인 측 후속 작업을 수행한다.
+ * 동기(@EventListener) 처리로 주문 생성 트랜잭션에 참여하여 Payment READY 엔티티를 함께 저장한다.
+ * OrderService가 PaymentService를 직접 주입하지 않도록 하여 순환 의존성을 제거한다.
+ * </p>
+ */
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+    private final PaymentService paymentService;
+
+    @EventListener
+    public void on(OrderPlacedEvent event) {
+        paymentService.createReady(event.orderId(), event.totalAmount(), event.finalAmount());
+    }
+}

--- a/src/main/java/ccommit/stylehub/payment/event/PaymentFailedEvent.java
+++ b/src/main/java/ccommit/stylehub/payment/event/PaymentFailedEvent.java
@@ -1,0 +1,13 @@
+package ccommit.stylehub.payment.event;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * 결제창에서 사용자가 취소/실패해 failUrl로 리다이렉트된 시점에 발행되는 도메인 이벤트.
+ * Order 도메인의 동기 리스너에서 주문 취소(재고 복구), AFTER_COMMIT 리스너에서 Redis 타임아웃 제거를 수행한다.
+ * </p>
+ */
+public record PaymentFailedEvent(Long orderId) {
+}

--- a/src/main/java/ccommit/stylehub/payment/event/PaymentFullyCanceledEvent.java
+++ b/src/main/java/ccommit/stylehub/payment/event/PaymentFullyCanceledEvent.java
@@ -1,0 +1,13 @@
+package ccommit.stylehub.payment.event;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * 결제가 전액 취소된 시점에 발행되는 도메인 이벤트.
+ * Order 도메인의 동기 리스너에서 결제 완료 주문을 취소 상태로 전이한다.
+ * </p>
+ */
+public record PaymentFullyCanceledEvent(Long orderId) {
+}

--- a/src/main/java/ccommit/stylehub/payment/port/PaymentPort.java
+++ b/src/main/java/ccommit/stylehub/payment/port/PaymentPort.java
@@ -1,17 +1,17 @@
 package ccommit.stylehub.payment.port;
 
-import ccommit.stylehub.order.entity.Order;
-
 /**
  * @author WonJin Bae
  * @created 2026/04/20
+ * @modified 2026/04/22 by WonJin - refactor: Order 엔티티 직접 의존 제거, primitives로 시그니처 변경 (도메인 경계 누수 해소)
  *
  * <p>
  * Payment 도메인이 외부에 제공하는 포트 인터페이스이다.
  * 결제 대기 건 생성을 제공한다.
+ * 이벤트 기반 리팩터링 이후 현재는 구현체가 없고 호출부도 이벤트로 통합되어 고아 상태이며, 후속 PR에서 제거 예정이다.
  * </p>
  */
 public interface PaymentPort {
 
-    void createReady(Order order, int totalAmount, int finalAmount);
+    void createReady(Long orderId, int totalAmount, int finalAmount);
 }

--- a/src/main/java/ccommit/stylehub/payment/port/PaymentPort.java
+++ b/src/main/java/ccommit/stylehub/payment/port/PaymentPort.java
@@ -1,0 +1,17 @@
+package ccommit.stylehub.payment.port;
+
+import ccommit.stylehub.order.entity.Order;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/20
+ *
+ * <p>
+ * Payment 도메인이 외부에 제공하는 포트 인터페이스이다.
+ * 결제 대기 건 생성을 제공한다.
+ * </p>
+ */
+public interface PaymentPort {
+
+    void createReady(Order order, int totalAmount, int finalAmount);
+}

--- a/src/main/java/ccommit/stylehub/payment/service/PaymentService.java
+++ b/src/main/java/ccommit/stylehub/payment/service/PaymentService.java
@@ -2,9 +2,9 @@ package ccommit.stylehub.payment.service;
 
 import ccommit.stylehub.common.exception.BusinessException;
 import ccommit.stylehub.common.exception.ErrorCode;
+import ccommit.stylehub.order.port.OrderPort;
+import ccommit.stylehub.payment.port.PaymentPort;
 import ccommit.stylehub.order.entity.Order;
-import ccommit.stylehub.order.scheduler.OrderPaymentTimeout;
-import ccommit.stylehub.order.service.OrderService;
 import ccommit.stylehub.payment.client.PaymentClientFactory;
 import ccommit.stylehub.payment.policy.PaymentValidator;
 import ccommit.stylehub.payment.dto.response.PaymentResponse;
@@ -26,13 +26,19 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
-public class PaymentService {
+public class PaymentService implements PaymentPort {
 
     private final PaymentRepository paymentRepository;
     private final PaymentClientFactory paymentClientFactory;
     private final PaymentValidator paymentValidator;
-    private final OrderPaymentTimeout orderPaymentTimeout;
-    private final OrderService orderService;
+    private final OrderPort orderPort;
+
+    @Override
+    public void createReady(Order order, int totalAmount, int finalAmount) {
+        paymentRepository.save(Payment.create(
+                order, "", "주문 결제", finalAmount, totalAmount, finalAmount
+        ));
+    }
 
     // 토스 결제를 확인하고 우리 DB에 승인 처리한다.
     @Transactional
@@ -51,7 +57,7 @@ public class PaymentService {
     private PaymentResponse approvePayment(Payment payment, String paymentKey, Integer amount) {
         payment.approve(paymentKey, amount);
         payment.getOrder().markPaid();
-        orderPaymentTimeout.removeTimeout(payment.getOrder().getOrderId());
+        orderPort.removeTimeout(payment.getOrder().getOrderId());
 
         return PaymentResponse.from(payment);
     }
@@ -87,13 +93,13 @@ public class PaymentService {
         payment.abort();
 
         Order order = payment.getOrder();
-        orderService.cancelOrder(order.getOrderId());
-        orderPaymentTimeout.removeTimeout(order.getOrderId());
+        orderPort.cancelOrder(order.getOrderId());
+        orderPort.removeTimeout(order.getOrderId());
     }
 
     private void cancelOrderIfFullyCanceled(Payment payment) {
         if (payment.isFullyCanceled()) {
-            orderService.cancelPaidOrder(payment.getOrder().getOrderId());
+            orderPort.cancelPaidOrder(payment.getOrder().getOrderId());
         }
     }
 

--- a/src/main/java/ccommit/stylehub/payment/service/PaymentService.java
+++ b/src/main/java/ccommit/stylehub/payment/service/PaymentService.java
@@ -2,15 +2,18 @@ package ccommit.stylehub.payment.service;
 
 import ccommit.stylehub.common.exception.BusinessException;
 import ccommit.stylehub.common.exception.ErrorCode;
-import ccommit.stylehub.order.port.OrderPort;
-import ccommit.stylehub.payment.port.PaymentPort;
 import ccommit.stylehub.order.entity.Order;
 import ccommit.stylehub.payment.client.PaymentClientFactory;
-import ccommit.stylehub.payment.policy.PaymentValidator;
 import ccommit.stylehub.payment.dto.response.PaymentResponse;
 import ccommit.stylehub.payment.entity.Payment;
+import ccommit.stylehub.payment.event.PaymentApprovedEvent;
+import ccommit.stylehub.payment.event.PaymentFailedEvent;
+import ccommit.stylehub.payment.event.PaymentFullyCanceledEvent;
+import ccommit.stylehub.payment.policy.PaymentValidator;
 import ccommit.stylehub.payment.repository.PaymentRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,25 +21,30 @@ import org.springframework.transaction.annotation.Transactional;
  * @author WonJin Bae
  * @created 2026/04/01
  * @modified 2026/04/01 by WonJin - refactor: 검증 로직을 PaymentValidator로 분리
+ * @modified 2026/04/22 by WonJin - refactor: OrderPort 직접 의존 제거, Payment 이벤트 발행으로 전환 (순환 참조 해소)
+ * @modified 2026/04/22 by WonJin - refactor: createReady 시그니처 primitives로 변경, Order FK는 EntityManager.getReference 프록시로 처리 (도메인 경계 누수 해소)
  *
  * <p>
  * 결제 승인, 취소, 부분 취소를 담당한다.
  * 검증은 PaymentValidator, PG사 호출은 PaymentClientFactory에 위임한다.
+ * Order 도메인과는 ApplicationEventPublisher를 통해서만 통신해 순환 의존성을 제거했다.
+ * 외부 계약에서는 Order 엔티티를 받지 않고, 필요 시 EntityManager.getReference로 FK 프록시만 얻어 사용한다.
  * </p>
  */
 @Service
 @RequiredArgsConstructor
-public class PaymentService implements PaymentPort {
+public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentClientFactory paymentClientFactory;
     private final PaymentValidator paymentValidator;
-    private final OrderPort orderPort;
+    private final ApplicationEventPublisher eventPublisher;
+    private final EntityManager em;
 
-    @Override
-    public void createReady(Order order, int totalAmount, int finalAmount) {
+    public void createReady(Long orderId, int totalAmount, int finalAmount) {
+        Order orderRef = em.getReference(Order.class, orderId);
         paymentRepository.save(Payment.create(
-                order, "", "주문 결제", finalAmount, totalAmount, finalAmount
+                orderRef, "", "주문 결제", finalAmount, totalAmount, finalAmount
         ));
     }
 
@@ -57,7 +65,7 @@ public class PaymentService implements PaymentPort {
     private PaymentResponse approvePayment(Payment payment, String paymentKey, Integer amount) {
         payment.approve(paymentKey, amount);
         payment.getOrder().markPaid();
-        orderPort.removeTimeout(payment.getOrder().getOrderId());
+        eventPublisher.publishEvent(new PaymentApprovedEvent(payment.getOrder().getOrderId()));
 
         return PaymentResponse.from(payment);
     }
@@ -79,7 +87,9 @@ public class PaymentService implements PaymentPort {
     // 토스 취소 성공 후 우리 DB에 취소를 반영한다.
     private PaymentResponse applyCancellation(Payment payment, String cancelReason, Integer cancelAmount) {
         payment.cancel(cancelReason, cancelAmount);
-        cancelOrderIfFullyCanceled(payment);
+        if (payment.isFullyCanceled()) {
+            eventPublisher.publishEvent(new PaymentFullyCanceledEvent(payment.getOrder().getOrderId()));
+        }
 
         return PaymentResponse.from(payment);
     }
@@ -91,16 +101,7 @@ public class PaymentService implements PaymentPort {
         Payment payment = findPaymentByOrderId(pgOrderId);
 
         payment.abort();
-
-        Order order = payment.getOrder();
-        orderPort.cancelOrder(order.getOrderId());
-        orderPort.removeTimeout(order.getOrderId());
-    }
-
-    private void cancelOrderIfFullyCanceled(Payment payment) {
-        if (payment.isFullyCanceled()) {
-            orderPort.cancelPaidOrder(payment.getOrder().getOrderId());
-        }
+        eventPublisher.publishEvent(new PaymentFailedEvent(payment.getOrder().getOrderId()));
     }
 
     private Payment findPaymentByOrderId(String pgOrderId) {

--- a/src/main/java/ccommit/stylehub/product/controller/ProductController.java
+++ b/src/main/java/ccommit/stylehub/product/controller/ProductController.java
@@ -10,7 +10,7 @@ import ccommit.stylehub.product.dto.response.ProductOptionResponse;
 import ccommit.stylehub.product.dto.response.ProductResponse;
 import ccommit.stylehub.product.enums.MainCategory;
 import ccommit.stylehub.product.enums.SubCategory;
-import ccommit.stylehub.product.service.ProductService;
+import ccommit.stylehub.product.service.ProductApplicationService;
 import ccommit.stylehub.user.enums.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -40,7 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProductController {
 
-    private final ProductService productService;
+    private final ProductApplicationService productApplicationService;
 
     //공개 API (비인증)
     @GetMapping("/products")
@@ -50,12 +50,12 @@ public class ProductController {
             @RequestParam(required = false) MainCategory mainCategory,
             @RequestParam(required = false) SubCategory subCategory,
             @RequestParam(required = false) Integer pageSize) {
-        return ResponseEntity.ok(productService.getProducts(cursor, storeId, mainCategory, subCategory, pageSize));
+        return ResponseEntity.ok(productApplicationService.getProducts(cursor, storeId, mainCategory, subCategory, pageSize));
     }
 
     @GetMapping("/products/{productId}")
     public ResponseEntity<ProductResponse> getProduct(@PathVariable Long productId) {
-        return ResponseEntity.ok(productService.getProduct(productId));
+        return ResponseEntity.ok(productApplicationService.getProduct(productId));
     }
 
     //  스토어 API (STORE 권한 필요)
@@ -67,7 +67,7 @@ public class ProductController {
             @RequestParam(required = false) Integer pageSize,
             HttpServletRequest httpRequest) {
         Long userId = SessionUtils.getUserId(httpRequest);
-        return ResponseEntity.ok(productService.getMyStoreProducts(userId, storeId, cursor, pageSize));
+        return ResponseEntity.ok(productApplicationService.getMyStoreProducts(userId, storeId, cursor, pageSize));
     }
 
     @PostMapping("/stores/{storeId}/products")
@@ -78,18 +78,17 @@ public class ProductController {
             HttpServletRequest httpRequest) {
         Long userId = SessionUtils.getUserId(httpRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(productService.registerProduct(userId, storeId, request));
+                .body(productApplicationService.registerProduct(userId, storeId, request));
     }
 
     @PatchMapping("/stores/{storeId}/products/{productId}/options/{optionId}/stock")
     @RequiredRole(UserRole.STORE)
     public ResponseEntity<ProductOptionResponse> updateStock(
             @PathVariable Long storeId,
-            @PathVariable Long productId,
             @PathVariable Long optionId,
             @Valid @RequestBody StockUpdateRequest request,
             HttpServletRequest httpRequest) {
         Long userId = SessionUtils.getUserId(httpRequest);
-        return ResponseEntity.ok(productService.updateStock(userId, storeId, productId, optionId, request.stockQuantity()));
+        return ResponseEntity.ok(productApplicationService.updateStock(userId, storeId, optionId, request.stockQuantity()));
     }
 }

--- a/src/main/java/ccommit/stylehub/product/port/ProductPort.java
+++ b/src/main/java/ccommit/stylehub/product/port/ProductPort.java
@@ -1,0 +1,19 @@
+package ccommit.stylehub.product.port;
+
+import ccommit.stylehub.product.entity.ProductOption;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/20
+ *
+ * <p>
+ * Product 도메인이 외부에 제공하는 포트 인터페이스이다.
+ * 재고 차감/복구를 제공한다.
+ * </p>
+ */
+public interface ProductPort {
+
+    ProductOption decreaseStockWithLock(Long optionId, int quantity);
+
+    void increaseStock(Long optionId, int quantity);
+}

--- a/src/main/java/ccommit/stylehub/product/service/ProductApplicationService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductApplicationService.java
@@ -1,0 +1,64 @@
+package ccommit.stylehub.product.service;
+
+import ccommit.stylehub.common.dto.CursorResponse;
+import ccommit.stylehub.product.dto.request.ProductCreateRequest;
+import ccommit.stylehub.product.dto.response.ProductListResponse;
+import ccommit.stylehub.product.dto.response.ProductOptionResponse;
+import ccommit.stylehub.product.dto.response.ProductResponse;
+import ccommit.stylehub.product.enums.MainCategory;
+import ccommit.stylehub.product.enums.SubCategory;
+import ccommit.stylehub.user.entity.User;
+import ccommit.stylehub.user.port.UserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/22
+ *
+ * <p>
+ * Product 유스케이스를 오케스트레이션하는 Application 계층 서비스이다.
+ * 스토어 소유권 검증(UserPort)과 상품 도메인 로직(ProductService)을 조합해 Controller에 단일 진입점을 제공한다.
+ * 권한 검증은 Application 관심사이므로 Domain 계층(ProductService)에서 분리해 여기서 처리한다.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductApplicationService {
+
+    private final UserPort userPort;
+    private final ProductService productService;
+
+    @Transactional
+    public ProductResponse registerProduct(Long userId, Long storeId, ProductCreateRequest request) {
+        User owner = userPort.findApprovedStoreByOwner(userId, storeId);
+        return productService.registerProduct(owner, request);
+    }
+
+    @Transactional(readOnly = true)
+    public CursorResponse<ProductListResponse> getMyStoreProducts(Long userId, Long storeId,
+                                                                  Long cursor, Integer pageSize) {
+        userPort.validateApprovedStoreOwner(userId, storeId);
+        return productService.getMyStoreProducts(storeId, cursor, pageSize);
+    }
+
+    @Transactional
+    public ProductOptionResponse updateStock(Long userId, Long storeId,
+                                             Long optionId, Integer stockQuantity) {
+        userPort.validateApprovedStoreOwner(userId, storeId);
+        return productService.updateStock(optionId, stockQuantity);
+    }
+
+    @Transactional(readOnly = true)
+    public CursorResponse<ProductListResponse> getProducts(Long cursor, Long storeId,
+                                                           MainCategory mainCategory,
+                                                           SubCategory subCategory, Integer pageSize) {
+        return productService.getProducts(cursor, storeId, mainCategory, subCategory, pageSize);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductResponse getProduct(Long productId) {
+        return productService.getProduct(productId);
+    }
+}

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -15,8 +15,9 @@ import ccommit.stylehub.product.enums.SubCategory;
 import ccommit.stylehub.product.repository.ProductOptionRepository;
 import ccommit.stylehub.product.repository.ProductQueryRepository;
 import ccommit.stylehub.product.repository.ProductRepository;
+import ccommit.stylehub.product.port.ProductPort;
+import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.user.entity.User;
-import ccommit.stylehub.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +41,7 @@ import java.util.Objects;
  */
 @Service
 @RequiredArgsConstructor
-public class ProductService {
+public class ProductService implements ProductPort {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 100;
@@ -48,7 +49,7 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final ProductOptionRepository productOptionRepository;
     private final ProductQueryRepository productQueryRepository;
-    private final UserService userService;
+    private final UserPort userPort;
     private final TransactionTemplate transactionTemplate;
 
     // 스토어 소유권, 승인 상태, 카테고리 조합을 검증한 뒤 상품과 옵션을 등록한다.
@@ -59,7 +60,7 @@ public class ProductService {
 
         RegisterResult result = Objects.requireNonNull(
                 transactionTemplate.execute(status -> {
-                    User storeOwner = userService.findApprovedStoreByOwner(userId, storeId);
+                    User storeOwner = userPort.findApprovedStoreByOwner(userId, storeId);
                     Product savedProduct = saveProduct(storeOwner, request.name(), request.mainCategory(),
                             request.subCategory(), request.description(), request.price(), request.imageUrl());
                     List<ProductOption> savedOptions = saveOptions(savedProduct, request.options());
@@ -75,7 +76,7 @@ public class ProductService {
      */
     @Transactional(readOnly = true)
     public CursorResponse<ProductListResponse> getMyStoreProducts(Long userId, Long storeId, Long cursor, Integer pageSize) {
-        userService.validateApprovedStoreOwner(userId, storeId);
+        userPort.findApprovedStoreByOwner(userId, storeId);
 
         int resolvedSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE;
 
@@ -94,7 +95,7 @@ public class ProductService {
     public ProductOptionResponse updateStock(Long userId, Long storeId, Long productId, Long optionId, Integer stockQuantity) {
         ProductOption option = Objects.requireNonNull(
                 transactionTemplate.execute(status -> {
-                    userService.validateApprovedStoreOwner(userId, storeId);
+                    userPort.findApprovedStoreByOwner(userId, storeId);
 
                     ProductOption target = productOptionRepository
                             .findByIdWithLock(optionId)
@@ -110,6 +111,7 @@ public class ProductService {
 
     // 비관적 락으로 재고를 차감한다. 호출자의 트랜잭션에 참여한다.
     // TODO: 대용량 트래픽 대응 시 Redis DECR 원자적 연산으로 전환 예정
+    @Override
     public ProductOption decreaseStockWithLock(Long optionId, int quantity) {
         ProductOption option = productOptionRepository.findByIdWithLock(optionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
@@ -118,6 +120,7 @@ public class ProductService {
     }
 
     // 비관적 락으로 재고를 복구한다. 주문 취소 시 사용.
+    @Override
     public void increaseStock(Long optionId, int quantity) {
         ProductOption option = productOptionRepository.findByIdWithLock(optionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -76,7 +76,7 @@ public class ProductService implements ProductPort {
      */
     @Transactional(readOnly = true)
     public CursorResponse<ProductListResponse> getMyStoreProducts(Long userId, Long storeId, Long cursor, Integer pageSize) {
-        userPort.findApprovedStoreByOwner(userId, storeId);
+        userPort.validateApprovedStoreOwner(userId, storeId);
 
         int resolvedSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE;
 
@@ -95,7 +95,7 @@ public class ProductService implements ProductPort {
     public ProductOptionResponse updateStock(Long userId, Long storeId, Long productId, Long optionId, Integer stockQuantity) {
         ProductOption option = Objects.requireNonNull(
                 transactionTemplate.execute(status -> {
-                    userPort.findApprovedStoreByOwner(userId, storeId);
+                    userPort.validateApprovedStoreOwner(userId, storeId);
 
                     ProductOption target = productOptionRepository
                             .findByIdWithLock(optionId)

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -1,10 +1,10 @@
 package ccommit.stylehub.product.service;
 
+import ccommit.stylehub.common.dto.CursorResponse;
 import ccommit.stylehub.common.exception.BusinessException;
 import ccommit.stylehub.common.exception.ErrorCode;
 import ccommit.stylehub.product.dto.request.ProductCreateRequest;
 import ccommit.stylehub.product.dto.request.ProductOptionRequest;
-import ccommit.stylehub.common.dto.CursorResponse;
 import ccommit.stylehub.product.dto.response.ProductListResponse;
 import ccommit.stylehub.product.dto.response.ProductOptionResponse;
 import ccommit.stylehub.product.dto.response.ProductResponse;
@@ -12,20 +12,17 @@ import ccommit.stylehub.product.entity.Product;
 import ccommit.stylehub.product.entity.ProductOption;
 import ccommit.stylehub.product.enums.MainCategory;
 import ccommit.stylehub.product.enums.SubCategory;
+import ccommit.stylehub.product.port.ProductPort;
 import ccommit.stylehub.product.repository.ProductOptionRepository;
 import ccommit.stylehub.product.repository.ProductQueryRepository;
 import ccommit.stylehub.product.repository.ProductRepository;
-import ccommit.stylehub.product.port.ProductPort;
-import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * @author WonJin Bae
@@ -33,10 +30,11 @@ import java.util.Objects;
  * @modified 2026/03/27 by WonJin - feat: 내 스토어 상품 목록 조회 추가
  * @modified 2026/03/27 by WonJin - feat: 비관적 락 재고 차감/복구 메서드 추가
  * @modified 2026/04/01 by WonJin - refactor: ProductViewService를 ProductService로 통합
+ * @modified 2026/04/22 by WonJin - refactor: UserPort 의존 제거, 권한 검증은 ProductApplicationService로 이관 (도메인 서비스는 자기 도메인만 알도록 분리)
  *
  * <p>
- * 상품 등록, 재고 관리, 조회를 담당한다.
- * 스토어 검증은 StoreService를 통해 처리하여 도메인 간 결합을 방지한다.
+ * 상품 등록, 재고 관리, 조회를 담당하는 순수 도메인 서비스이다.
+ * 스토어 소유권 검증 같은 Application 관심사는 ProductApplicationService에서 처리한다.
  * </p>
  */
 @Service
@@ -49,36 +47,25 @@ public class ProductService implements ProductPort {
     private final ProductRepository productRepository;
     private final ProductOptionRepository productOptionRepository;
     private final ProductQueryRepository productQueryRepository;
-    private final UserPort userPort;
-    private final TransactionTemplate transactionTemplate;
 
-    // 스토어 소유권, 승인 상태, 카테고리 조합을 검증한 뒤 상품과 옵션을 등록한다.
-    public ProductResponse registerProduct(Long userId, Long storeId, ProductCreateRequest request) {
+    // 카테고리 조합 검증 후 상품과 옵션을 등록한다. 권한 검증은 상위 계층에서 수행된 상태라고 가정한다.
+    @Transactional
+    public ProductResponse registerProduct(User owner, ProductCreateRequest request) {
         validateCategoryCombination(request.mainCategory(), request.subCategory());
 
-        record RegisterResult(Product product, List<ProductOption> options) {}
+        Product savedProduct = saveProduct(owner, request.name(), request.mainCategory(),
+                request.subCategory(), request.description(), request.price(), request.imageUrl());
+        List<ProductOption> savedOptions = saveOptions(savedProduct, request.options());
 
-        RegisterResult result = Objects.requireNonNull(
-                transactionTemplate.execute(status -> {
-                    User storeOwner = userPort.findApprovedStoreByOwner(userId, storeId);
-                    Product savedProduct = saveProduct(storeOwner, request.name(), request.mainCategory(),
-                            request.subCategory(), request.description(), request.price(), request.imageUrl());
-                    List<ProductOption> savedOptions = saveOptions(savedProduct, request.options());
-                    return new RegisterResult(savedProduct, savedOptions);
-                })
-        );
-
-        return ProductResponse.from(result.product(), result.options());
+        return ProductResponse.from(savedProduct, savedOptions);
     }
 
     /**
-     * 내 스토어 상품 목록을 커서 기반으로 조회한다. 스토어 소유권 검증 포함.
+     * 내 스토어 상품 목록을 커서 기반으로 조회한다.
      */
     @Transactional(readOnly = true)
-    public CursorResponse<ProductListResponse> getMyStoreProducts(Long userId, Long storeId, Long cursor, Integer pageSize) {
-        userPort.validateApprovedStoreOwner(userId, storeId);
-
-        int resolvedSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE;
+    public CursorResponse<ProductListResponse> getMyStoreProducts(Long storeId, Long cursor, Integer pageSize) {
+        int resolvedSize = resolvePageSize(pageSize);
 
         List<Product> products = productQueryRepository.findProductsWithCursor(
                 cursor, storeId, resolvedSize + 1
@@ -91,22 +78,15 @@ public class ProductService implements ProductPort {
         return CursorResponse.of(productList, resolvedSize, ProductListResponse::productId);
     }
 
-    // 스토어 소유권, 승인 상태를 검증하고 해당 상품의 옵션 재고를 변경한다.
-    public ProductOptionResponse updateStock(Long userId, Long storeId, Long productId, Long optionId, Integer stockQuantity) {
-        ProductOption option = Objects.requireNonNull(
-                transactionTemplate.execute(status -> {
-                    userPort.validateApprovedStoreOwner(userId, storeId);
+    // 지정 옵션의 재고 수량을 변경한다.
+    @Transactional
+    public ProductOptionResponse updateStock(Long optionId, Integer stockQuantity) {
+        ProductOption target = productOptionRepository
+                .findByIdWithLock(optionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
 
-                    ProductOption target = productOptionRepository
-                            .findByIdWithLock(optionId)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
-
-                    target.updateStockQuantity(stockQuantity);
-                    return target;
-                })
-        );
-
-        return ProductOptionResponse.from(option);
+        target.updateStockQuantity(stockQuantity);
+        return ProductOptionResponse.from(target);
     }
 
     // 비관적 락으로 재고를 차감한다. 호출자의 트랜잭션에 참여한다.
@@ -132,9 +112,9 @@ public class ProductService implements ProductPort {
      */
     @Transactional(readOnly = true)
     public CursorResponse<ProductListResponse> getProducts(Long cursor, Long storeId,
-                                              MainCategory mainCategory,
-                                              SubCategory subCategory, Integer pageSize) {
-        int resolvedSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE;
+                                                           MainCategory mainCategory,
+                                                           SubCategory subCategory, Integer pageSize) {
+        int resolvedSize = resolvePageSize(pageSize);
 
         List<Product> products = productQueryRepository.findProductsWithCursor(
                 cursor, storeId, mainCategory, subCategory, resolvedSize + 1
@@ -157,6 +137,10 @@ public class ProductService implements ProductPort {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
         return ProductResponse.from(product, product.getOptions());
+    }
+
+    private int resolvePageSize(Integer size) {
+        return (size != null && size > 0) ? Math.min(size, MAX_PAGE_SIZE) : DEFAULT_PAGE_SIZE;
     }
 
     private Product saveProduct(User user, String name, MainCategory mainCategory,

--- a/src/main/java/ccommit/stylehub/user/port/UserPort.java
+++ b/src/main/java/ccommit/stylehub/user/port/UserPort.java
@@ -1,0 +1,22 @@
+package ccommit.stylehub.user.port;
+
+import ccommit.stylehub.user.entity.Address;
+import ccommit.stylehub.user.entity.User;
+
+/**
+ * @author WonJin Bae
+ * @created 2026/04/20
+ *
+ * <p>
+ * User 도메인이 외부에 제공하는 포트 인터페이스이다.
+ * 배송지 조회, 유저 조회, 스토어 소유권 검증을 제공한다.
+ * </p>
+ */
+public interface UserPort {
+
+    Address findAddressByOwner(Long userId, Long addressId);
+
+    User findUserById(Long userId);
+
+    User findApprovedStoreByOwner(Long userId, Long storeId);
+}

--- a/src/main/java/ccommit/stylehub/user/port/UserPort.java
+++ b/src/main/java/ccommit/stylehub/user/port/UserPort.java
@@ -6,10 +6,12 @@ import ccommit.stylehub.user.entity.User;
 /**
  * @author WonJin Bae
  * @created 2026/04/20
+ * @modified 2026/04/22 by WonJin - refactor: 검증 전용 메서드 validateApprovedStoreOwner 분리 (의도 명확화)
  *
  * <p>
  * User 도메인이 외부에 제공하는 포트 인터페이스이다.
- * 배송지 조회, 유저 조회, 스토어 소유권 검증을 제공한다.
+ * 배송지 조회, 유저 조회, 스토어 소유권 검증/조회를 제공한다.
+ * 검증만 필요한 경우 validateApprovedStoreOwner, 소유자 User 객체가 필요한 경우 findApprovedStoreByOwner를 사용한다.
  * </p>
  */
 public interface UserPort {
@@ -17,6 +19,8 @@ public interface UserPort {
     Address findAddressByOwner(Long userId, Long addressId);
 
     User findUserById(Long userId);
+
+    void validateApprovedStoreOwner(Long userId, Long storeId);
 
     User findApprovedStoreByOwner(Long userId, Long storeId);
 }

--- a/src/main/java/ccommit/stylehub/user/service/UserService.java
+++ b/src/main/java/ccommit/stylehub/user/service/UserService.java
@@ -161,6 +161,7 @@ public class UserService implements UserPort {
         user.registerStore(storeName, storeDescription);
     }
 
+    @Override
     public void validateApprovedStoreOwner(Long userId, Long storeId) {
         findApprovedStoreByOwner(userId, storeId);
     }

--- a/src/main/java/ccommit/stylehub/user/service/UserService.java
+++ b/src/main/java/ccommit/stylehub/user/service/UserService.java
@@ -8,6 +8,7 @@ import ccommit.stylehub.user.dto.request.UserLoginRequest;
 import ccommit.stylehub.user.dto.response.StoreResponse;
 import ccommit.stylehub.user.dto.response.StoreSignUpResponse;
 import ccommit.stylehub.user.dto.response.UserLoginResponse;
+import ccommit.stylehub.user.port.UserPort;
 import ccommit.stylehub.user.entity.Address;
 import ccommit.stylehub.user.entity.User;
 import ccommit.stylehub.user.enums.StoreStatus;
@@ -40,7 +41,7 @@ import java.util.function.Consumer;
  */
 @Service
 @RequiredArgsConstructor
-public class UserService {
+public class UserService implements UserPort {
 
     private static final int FIRST_LOGIN_POINT = 1000;
     private static final int DAILY_LOGIN_POINT = 10;
@@ -130,11 +131,13 @@ public class UserService {
     // 조회
     // ========================
 
+    @Override
     public User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
+    @Override
     public Address findAddressByOwner(Long userId, Long addressId) {
         Address address = userRepository.findAddressByIdWithUser(addressId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
@@ -162,6 +165,7 @@ public class UserService {
         findApprovedStoreByOwner(userId, storeId);
     }
 
+    @Override
     public User findApprovedStoreByOwner(Long userId, Long storeId) {
         User user = userRepository.findById(storeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));


### PR DESCRIPTION
 ## #️⃣Issue Number

  - #38 

  ## 📝 요약(Summary)
 - 헥사고날 아키텍처의 핵심 원칙인 Port(인터페이스)만 도입하여 도메인 간 서비스 직접 의존을 제거
 - 전체 헥사고날 전환 없이 Port/Adapter 패턴만 경량으로 차용
 - 4개 Port 인터페이스로 모든 도메인 간 서비스 의존을 간접화



  ## 🛠️PR 유형
 어떤 변경 사항이 있나요?

  - [] 새로운 기능 추가
  - [ ] 버그 수정
  - [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
  - [x] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [ ] 테스트 추가, 테스트 리팩토링
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

---
  ## 주요 설계 결정
 1. 전체 헥사고날 대신 Port만 도입한 이유

    - 현재 프로젝트 규모에서 헥사고날을 그대로 적용하면 클래스 수가 2~3배 늘어나 오버엔지니어링
    - 핵심 문제는 도메인 간 서비스 직접 참조이므로 Port(인터페이스)만 도입하여 간접 의존으로 전환
    - 기존 PG사 추상화에 사용한 PaymentClient 인터페이스 패턴과 동일한 방식
  
2. Port를 제공자 도메인에 배치
    - Port 인터페이스를 각 제공자 도메인의 port/ 패키지에 위치 (user/port/, product/port/ 등)
    - "이 도메인이 외부에 제공하는 계약"이라는 의미가 명확
    - 여러 소비자가 같은 Port를 공유할 수 있어 중복 인터페이스 방지
 
 3. 도입 후 의존 구조
    - 변경 전: OrderService → UserService, ProductService, PaymentRepository (직접 의존)
    - 변경 후: OrderService → UserPort, ProductPort, PaymentPort (인터페이스 의존)
    - PaymentService → OrderService 직접 의존도 OrderPort로 분리
    - 서비스 레이어의 도메인 간 직접 의존 0건
  
4. 기대 효과
    - 구현체 변경 시 소비자 코드 수정 불필요 (OCP)
    - 테스트 시 Port를 Mock으로 대체 가능 (테스트 용이성)
    - 순환 의존 원천 차단
    - 폴더 구조를 크게 바꾸지 않고 핵심 원칙만 적용


2. 배송 상태 변경 검증 3단계
  - @RequiredRole(UserRole.STORE): STORE 역할 확인
  - storeService.validateApprovedStoreOwner(): 본인 스토어 + 승인 상태 확인
  - orderService.validateStoreOrder(): 해당 주문에 본인 스토어 상품이 포함되어 있는지 확인

                                                                                                           