### PR TITLE
Refactor/상품조회 api 성능개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Spring Cache (Redis 를 CacheManager 로 활용)
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'

--- a/performance/locustfile_product.py
+++ b/performance/locustfile_product.py
@@ -1,0 +1,89 @@
+"""
+시나리오 1: 상품 조회 (읽기 부하)
+
+측정 목표
+  - P95 < 300ms, P99 < 500ms, 에러율 < 0.1%
+  - 커서 페이지네이션 + JOIN FETCH 의 실제 성능
+  - 필터 조합(스토어/카테고리)에 따른 쿼리 플랜 변화 관찰
+
+실행 방법
+  # 웹 UI 모드 (부하 단계별로 수동 제어)
+  locust -f performance/locustfile_product.py --host=http://localhost:8080
+  → 브라우저 http://localhost:8089 접속
+
+  # Headless 모드 (CSV 결과 저장 — Warm-up 예시)
+  locust -f performance/locustfile_product.py --host=http://localhost:8080 \\
+         --headless -u 10 -r 2 -t 30s \\
+         --csv=performance/results/product_warmup
+
+부하 단계 (시나리오 문서 기준)
+  단계      Users  Spawn  Duration
+  Warm-up    10    2/s     30s
+  Light      50    10/s    2m
+  Medium    200    20/s    3m
+  Heavy     500    50/s    5m
+  Spike    1000   100/s    1m
+"""
+import random
+from locust import HttpUser, task, between
+
+
+class ProductReadUser(HttpUser):
+    # 가상 유저가 요청 간 대기하는 시간 (초). 실제 사용자의 클릭/스크롤 간격을 흉내낸다.
+    # 너무 짧으면 비현실적 봇 부하가 되어 측정 왜곡이 생긴다.
+    wait_time = between(0.5, 2.0)
+
+    # 각 가상 유저가 테스트 시작 시 1회만 수행한다.
+    # 실제 DB에 존재하는 productId 목록을 미리 확보해 이후 커서/상세 호출 시 재사용한다.
+    def on_start(self):
+        response = self.client.get("/api/v1/products?pageSize=50")
+        if response.status_code == 200:
+            items = response.json().get("items", [])
+            self.product_ids = [item["productId"] for item in items]
+        else:
+            self.product_ids = []
+
+    @task(5)   # 가중치 5: 가장 빈번한 호출 패턴
+    def list_products_first_page(self):
+        """첫 페이지 조회 (커서 없음)"""
+        self.client.get("/api/v1/products", name="GET /products (first page)")
+
+    @task(5)
+    def list_products_next_page(self):
+        """다음 페이지 조회 (커서 기반)"""
+        if not self.product_ids:
+            return
+        cursor = random.choice(self.product_ids)
+        self.client.get(
+            f"/api/v1/products?cursor={cursor}",
+            name="GET /products (next page)",
+        )
+
+    @task(2)
+    def list_products_by_store(self):
+        """스토어 필터 조회"""
+        # 실제 존재하는 store_id 범위로 조정 필요 (시드 데이터의 스토어 유저 id)
+        store_id = random.randint(1, 3)
+        self.client.get(
+            f"/api/v1/products?storeId={store_id}",
+            name="GET /products (by store)",
+        )
+
+    @task(2)
+    def list_products_by_category(self):
+        """카테고리 필터 조회 (대·소분류 조합)"""
+        self.client.get(
+            "/api/v1/products?mainCategory=TOP&subCategory=T_SHIRT",
+            name="GET /products (by category)",
+        )
+
+    @task(3)
+    def get_product_detail(self):
+        """단건 상세 조회 (JOIN FETCH 성능)"""
+        if not self.product_ids:
+            return
+        product_id = random.choice(self.product_ids)
+        self.client.get(
+            f"/api/v1/products/{product_id}",
+            name="GET /products/{id}",
+        )

--- a/performance/locustfile_product.py
+++ b/performance/locustfile_product.py
@@ -25,23 +25,46 @@
   Spike    1000   100/s    1m
 """
 import random
-from locust import HttpUser, task, between
+import requests
+from locust import HttpUser, task, between, events
+
+
+# 모든 가상 유저가 공유하는 productId 목록.
+# test_start 리스너가 테스트 시작 시 1번만 채우므로 read-only 로 안전하게 공유 가능하다.
+PRODUCT_IDS: list[int] = []
+
+
+@events.test_start.add_listener
+def fetch_product_ids(environment, **kwargs):
+    """
+    모든 유저가 시작되기 전 1번만 실행되는 셋업 단계.
+    Locust client 가 아닌 raw requests 로 호출해 측정 stats 에서 격리한다.
+    유저별 on_start 에 두면 N명 = N번 init 호출이 stats 에 섞여 RPS/응답시간을 왜곡한다.
+    """
+    global PRODUCT_IDS
+    host = environment.host
+    if not host:
+        print("[setup] host 가 설정되지 않아 productId 목록을 비워둔다.")
+        PRODUCT_IDS = []
+        return
+
+    try:
+        response = requests.get(f"{host}/api/v1/products?pageSize=50", timeout=5)
+        if response.status_code == 200:
+            PRODUCT_IDS = [item["productId"] for item in response.json().get("items", [])]
+            print(f"[setup] productId 목록 확보: {len(PRODUCT_IDS)}개")
+        else:
+            print(f"[setup] 상품 조회 실패 status={response.status_code}, 빈 목록으로 진행")
+            PRODUCT_IDS = []
+    except requests.RequestException as e:
+        print(f"[setup] 상품 조회 예외: {e}, 빈 목록으로 진행")
+        PRODUCT_IDS = []
 
 
 class ProductReadUser(HttpUser):
     # 가상 유저가 요청 간 대기하는 시간 (초). 실제 사용자의 클릭/스크롤 간격을 흉내낸다.
     # 너무 짧으면 비현실적 봇 부하가 되어 측정 왜곡이 생긴다.
     wait_time = between(0.5, 2.0)
-
-    # 각 가상 유저가 테스트 시작 시 1회만 수행한다.
-    # 실제 DB에 존재하는 productId 목록을 미리 확보해 이후 커서/상세 호출 시 재사용한다.
-    def on_start(self):
-        response = self.client.get("/api/v1/products?pageSize=50")
-        if response.status_code == 200:
-            items = response.json().get("items", [])
-            self.product_ids = [item["productId"] for item in items]
-        else:
-            self.product_ids = []
 
     @task(5)   # 가중치 5: 가장 빈번한 호출 패턴
     def list_products_first_page(self):
@@ -51,9 +74,9 @@ class ProductReadUser(HttpUser):
     @task(5)
     def list_products_next_page(self):
         """다음 페이지 조회 (커서 기반)"""
-        if not self.product_ids:
+        if not PRODUCT_IDS:
             return
-        cursor = random.choice(self.product_ids)
+        cursor = random.choice(PRODUCT_IDS)
         self.client.get(
             f"/api/v1/products?cursor={cursor}",
             name="GET /products (next page)",
@@ -80,9 +103,9 @@ class ProductReadUser(HttpUser):
     @task(3)
     def get_product_detail(self):
         """단건 상세 조회 (JOIN FETCH 성능)"""
-        if not self.product_ids:
+        if not PRODUCT_IDS:
             return
-        product_id = random.choice(self.product_ids)
+        product_id = random.choice(PRODUCT_IDS)
         self.client.get(
             f"/api/v1/products/{product_id}",
             name="GET /products/{id}",

--- a/performance/locustfile_product_cache_miss.py
+++ b/performance/locustfile_product_cache_miss.py
@@ -1,0 +1,139 @@
+"""
+시나리오: 상품 조회 (캐시 cold-start / cache miss 측정)
+
+측정 목표
+  - 캐시가 비어있는 상태에서 Heavy 부하가 들어왔을 때 DB 가 버티는지
+  - cache hit 상태 측정(locustfile_product.py)과 별개로 DB 처리 한계 검증
+  - thundering herd 발생 시 응답 시간 분포·실패율·DB 응답 패턴
+
+차이점 vs locustfile_product.py
+  - test_start 시 Redis 의 products:* 캐시 키를 모두 삭제 → cold-start 상태로 시작
+  - 부하 시작 시점의 모든 요청이 cache miss → DB 직격
+  - 시간이 지나면 캐시가 채워져 hit 으로 전환되므로, 짧은 시간(1~2 분) 측정이 의미 있음
+
+실행 방법
+  # 사전 조건: Redis 가 localhost:6379 에 떠 있어야 함, redis-py 설치 필요 (pip install redis)
+
+  # cold-start spike: 0→500 users 빠르게 spawn → 빈 캐시에 부하 전체 투입
+  locust -f performance/locustfile_product_cache_miss.py \\
+         --host=http://localhost:8080 \\
+         --headless -u 500 -r 200 -t 1m \\
+         --csv=performance/results/product_cache_miss_500
+
+  # cold-start heavy: 1000 users 빠른 spawn
+  locust -f performance/locustfile_product_cache_miss.py \\
+         --host=http://localhost:8080 \\
+         --headless -u 1000 -r 500 -t 1m \\
+         --csv=performance/results/product_cache_miss_1000
+
+해석 가이드
+  - 측정 시작 직후 P95 가 hit 상태(30~70ms)보다 크게 튀면 정상 — 그 폭이 DB 가 받는 부담
+  - 1~2 분 지나면 캐시가 채워져 hit 응답 시간으로 수렴
+  - DB 가 못 버틸 때 시그널: 5xx 발생, P99 가 시간이 지나도 안 떨어짐, HikariCP 고갈
+  - 같은 부하를 hit 시나리오와 비교했을 때의 P95 격차가 = 캐시가 가려놓던 진짜 DB 부하
+"""
+import random
+import requests
+from locust import HttpUser, task, between, events
+
+
+# 모든 가상 유저가 공유하는 productId 목록.
+# test_start 리스너가 1번만 채우므로 read-only 로 안전하게 공유 가능하다.
+PRODUCT_IDS: list[int] = []
+
+
+@events.test_start.add_listener
+def setup_cold_start_state(environment, **kwargs):
+    """
+    테스트 시작 전 1회 실행:
+      1) productId 목록 확보 (raw requests 호출 → Locust stats 격리)
+      2) Redis 의 products:* 캐시 키를 모두 삭제 → 부하 시작 시점이 cold-start 상태
+    유저별 on_start 가 아니므로 N명이어도 init 호출은 1번뿐이다.
+    """
+    global PRODUCT_IDS
+    host = environment.host
+    if not host:
+        print("[setup] host 가 설정되지 않아 productId 목록을 비워둔다.")
+        PRODUCT_IDS = []
+        return
+
+    # 1) productId 목록 사전 확보
+    try:
+        response = requests.get(f"{host}/api/v1/products?pageSize=50", timeout=5)
+        if response.status_code == 200:
+            PRODUCT_IDS = [item["productId"] for item in response.json().get("items", [])]
+            print(f"[setup] productId 목록 확보: {len(PRODUCT_IDS)}개")
+        else:
+            print(f"[setup] 상품 조회 실패 status={response.status_code}, 빈 목록으로 진행")
+            PRODUCT_IDS = []
+    except requests.RequestException as e:
+        print(f"[setup] 상품 조회 예외: {e}, 빈 목록으로 진행")
+        PRODUCT_IDS = []
+
+    # 2) Redis products:* 캐시 무효화 — productId 사전 확보 직후 실행해
+    #    setup 단계에서 채워진 캐시 키도 함께 비운다.
+    try:
+        import redis
+        r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+        deleted = 0
+        # Spring RedisCache 기본 키 포맷: "<cacheName>::<key>"
+        # ProductService 의 캐시는 products:firstPage / products:detail 두 종류
+        for pattern in ("products:firstPage*", "products:detail*"):
+            for key in r.scan_iter(pattern, count=500):
+                r.delete(key)
+                deleted += 1
+        print(f"[setup] 캐시 무효화 완료: {deleted}개 키 삭제 (cold-start 상태로 부하 시작)")
+    except ImportError:
+        print("[setup] redis 패키지 미설치 — pip install redis 필요. 캐시 무효화 건너뜀 (측정 의미 약화)")
+    except Exception as e:
+        print(f"[setup] 캐시 무효화 예외: {e} (측정 의미 약화)")
+
+
+class ProductReadUser(HttpUser):
+    # 가상 유저가 요청 간 대기하는 시간. cold-start 측정에선 thundering herd 를 강하게 내기 위해
+    # 기본 시나리오보다 짧게 잡아도 된다. 다만 측정 결과의 비교 가능성을 위해 동일 값을 유지.
+    wait_time = between(0.5, 2.0)
+
+    @task(5)
+    def list_products_first_page(self):
+        """첫 페이지 조회 — cache miss 시 DB 쿼리 발생, 1~2회 후 캐시 적재되어 hit 으로 전환"""
+        self.client.get("/api/v1/products", name="GET /products (first page)")
+
+    @task(5)
+    def list_products_next_page(self):
+        """다음 페이지 조회 — cursor 가 있어 캐시되지 않음 → 항상 DB 직격"""
+        if not PRODUCT_IDS:
+            return
+        cursor = random.choice(PRODUCT_IDS)
+        self.client.get(
+            f"/api/v1/products?cursor={cursor}",
+            name="GET /products (next page)",
+        )
+
+    @task(2)
+    def list_products_by_store(self):
+        """스토어 필터 조회 — 필터 조합별로 캐시 키가 분리되어 cold-start miss 발생 가능성 ↑"""
+        store_id = random.randint(1, 3)
+        self.client.get(
+            f"/api/v1/products?storeId={store_id}",
+            name="GET /products (by store)",
+        )
+
+    @task(2)
+    def list_products_by_category(self):
+        """카테고리 필터 조회 — by store 와 동일하게 cold-start miss 빈도 ↑"""
+        self.client.get(
+            "/api/v1/products?mainCategory=TOP&subCategory=T_SHIRT",
+            name="GET /products (by category)",
+        )
+
+    @task(3)
+    def get_product_detail(self):
+        """단건 상세 조회 — productId 별로 캐시 키 분리되어 cold-start 시 대부분 miss"""
+        if not PRODUCT_IDS:
+            return
+        product_id = random.choice(PRODUCT_IDS)
+        self.client.get(
+            f"/api/v1/products/{product_id}",
+            name="GET /products/{id}",
+        )

--- a/src/main/java/ccommit/stylehub/StylehubApplication.java
+++ b/src/main/java/ccommit/stylehub/StylehubApplication.java
@@ -3,6 +3,7 @@ package ccommit.stylehub;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -21,6 +22,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableScheduling
+@EnableCaching
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class StylehubApplication {

--- a/src/main/java/ccommit/stylehub/common/config/RedisConfig.java
+++ b/src/main/java/ccommit/stylehub/common/config/RedisConfig.java
@@ -1,19 +1,20 @@
 package ccommit.stylehub.common.config;
 
+import ccommit.stylehub.common.dto.CursorResponse;
+import ccommit.stylehub.product.dto.response.ProductListResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import tools.jackson.databind.DefaultTyping;
+import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
-import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
 
 import java.time.Duration;
 
@@ -41,25 +42,19 @@ public class RedisConfig {
     /**
      * Spring Cache 전용 CacheManager.
      * - 키: String (사람이 읽기 쉬운 형태, 예: products:firstPage::20)
-     * - 값: JSON 직렬화 (GenericJacksonJsonRedisSerializer, Jackson 3.x)
-     *   타입 정보를 인라인 `@class` 프로퍼티(AsProperty)로 기록해 record/제네릭도 안전하게 역직렬화
-     *   (WrapperArray 방식은 final record 루트에서 타입 래퍼가 생략돼 역직렬화가 깨짐)
-     * - Spring Cache null marker 지원 활성화 (NullValue 직렬화)
+     * - 값: CursorResponse&lt;ProductListResponse&gt; 타입드 JSON 직렬화
+     *   (Jackson 3 은 default typing EVERYTHING 모드가 제거되어 final record 에는 타입 정보를 남길 수 없다.
+     *   캐시 타입이 단일이므로 고정 JavaType 기반 직렬화기로 안전하게 역직렬화한다.)
      * - 기본 TTL: 30초 (신상품 반영 지연 허용 범위)
-     * - null 값은 캐시하지 않음 (의미 없음)
+     * - null 값은 캐시하지 않음
      */
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-                .allowIfBaseType(Object.class)
-                .build();
+        ObjectMapper objectMapper = JsonMapper.builder().build();
+        JavaType cursorResponseType = objectMapper.getTypeFactory()
+                .constructParametricType(CursorResponse.class, ProductListResponse.class);
 
-        ObjectMapper objectMapper = JsonMapper.builder()
-                .activateDefaultTypingAsProperty(typeValidator, DefaultTyping.NON_FINAL, "@class")
-                .build();
-
-        GenericJacksonJsonRedisSerializer valueSerializer =
-                new GenericJacksonJsonRedisSerializer(objectMapper);
+        RedisSerializer<Object> valueSerializer = typedJsonSerializer(objectMapper, cursorResponseType);
 
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofSeconds(30))
@@ -72,5 +67,34 @@ public class RedisConfig {
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
                 .build();
+    }
+
+    // 고정 JavaType 기반 RedisSerializer. default typing 없이 정확한 타입으로 역직렬화한다.
+    private static RedisSerializer<Object> typedJsonSerializer(ObjectMapper mapper, JavaType type) {
+        return new RedisSerializer<>() {
+            @Override
+            public byte[] serialize(Object value) {
+                if (value == null) {
+                    return new byte[0];
+                }
+                try {
+                    return mapper.writeValueAsBytes(value);
+                } catch (Exception e) {
+                    throw new SerializationException("Redis 캐시 JSON 직렬화 실패", e);
+                }
+            }
+
+            @Override
+            public Object deserialize(byte[] bytes) {
+                if (bytes == null || bytes.length == 0) {
+                    return null;
+                }
+                try {
+                    return mapper.readValue(bytes, type);
+                } catch (Exception e) {
+                    throw new SerializationException("Redis 캐시 JSON 역직렬화 실패", e);
+                }
+            }
+        };
     }
 }

--- a/src/main/java/ccommit/stylehub/common/config/RedisConfig.java
+++ b/src/main/java/ccommit/stylehub/common/config/RedisConfig.java
@@ -2,6 +2,7 @@ package ccommit.stylehub.common.config;
 
 import ccommit.stylehub.common.dto.CursorResponse;
 import ccommit.stylehub.product.dto.response.ProductListResponse;
+import ccommit.stylehub.product.dto.response.ProductResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -17,12 +18,14 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.Duration;
+import java.util.Map;
 
 /**
  * @author WonJin Bae
  * @created 2026/03/27
  * @modified 2026/04/01 by WonJin - docs: Lettuce vs Jedis 비교 및 선택 이유 추가
  * @modified 2026/04/24 by WonJin - feat: Spring Cache 용 RedisCacheManager 추가 (first page 캐싱)
+ * @modified 2026/04/24 by WonJin - feat: 캐시 범위 확대 + 상세 조회 캐시 추가 (Step 5 — 1,000/2,000 users 대응)
  *
  * Redis 설정을 담당한다. 분산 락/타임아웃에는 StringRedisTemplate, 응답 캐싱에는 RedisCacheManager 를 사용한다.
  *
@@ -34,6 +37,9 @@ import java.time.Duration;
 @Configuration
 public class RedisConfig {
 
+    private static final String LIST_CACHE = "products:firstPage";
+    private static final String DETAIL_CACHE = "products:detail";
+
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
@@ -41,32 +47,40 @@ public class RedisConfig {
 
     /**
      * Spring Cache 전용 CacheManager.
-     * - 키: String (사람이 읽기 쉬운 형태, 예: products:firstPage::20)
-     * - 값: CursorResponse&lt;ProductListResponse&gt; 타입드 JSON 직렬화
-     *   (Jackson 3 은 default typing EVERYTHING 모드가 제거되어 final record 에는 타입 정보를 남길 수 없다.
-     *   캐시 타입이 단일이므로 고정 JavaType 기반 직렬화기로 안전하게 역직렬화한다.)
-     * - 기본 TTL: 30초 (신상품 반영 지연 허용 범위)
+     * - 키: String (사람이 읽기 쉬운 형태, 예: products:firstPage::size=20|store=null|main=TOP|sub=T_SHIRT)
+     * - 값: 캐시별 고정 JavaType JSON 직렬화 (Jackson 3.x, default typing 미사용 — record 와 안전 호환)
+     * - 캐시별 설정:
+     *     products:firstPage (목록 조회)   → CursorResponse&lt;ProductListResponse&gt;, TTL 60초
+     *     products:detail    (단건 상세)   → ProductResponse, TTL 60초
      * - null 값은 캐시하지 않음
      */
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        ObjectMapper objectMapper = JsonMapper.builder().build();
-        JavaType cursorResponseType = objectMapper.getTypeFactory()
+        ObjectMapper mapper = JsonMapper.builder().build();
+
+        JavaType listType = mapper.getTypeFactory()
                 .constructParametricType(CursorResponse.class, ProductListResponse.class);
+        JavaType detailType = mapper.constructType(ProductResponse.class);
 
-        RedisSerializer<Object> valueSerializer = typedJsonSerializer(objectMapper, cursorResponseType);
+        RedisCacheConfiguration listConfig = cacheConfig(typedJsonSerializer(mapper, listType));
+        RedisCacheConfiguration detailConfig = cacheConfig(typedJsonSerializer(mapper, detailType));
 
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofSeconds(30))
+        return RedisCacheManager.builder(connectionFactory)
+                .withInitialCacheConfigurations(Map.of(
+                        LIST_CACHE, listConfig,
+                        DETAIL_CACHE, detailConfig
+                ))
+                .build();
+    }
+
+    private static RedisCacheConfiguration cacheConfig(RedisSerializer<Object> valueSerializer) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(60))
                 .disableCachingNullValues()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(valueSerializer));
-
-        return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(config)
-                .build();
     }
 
     // 고정 JavaType 기반 RedisSerializer. default typing 없이 정확한 타입으로 역직렬화한다.

--- a/src/main/java/ccommit/stylehub/common/config/RedisConfig.java
+++ b/src/main/java/ccommit/stylehub/common/config/RedisConfig.java
@@ -2,29 +2,33 @@ package ccommit.stylehub.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.DefaultTyping;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
+
+import java.time.Duration;
 
 /**
  * @author WonJin Bae
  * @created 2026/03/27
  * @modified 2026/04/01 by WonJin - docs: Lettuce vs Jedis 비교 및 선택 이유 추가
+ * @modified 2026/04/24 by WonJin - feat: Spring Cache 용 RedisCacheManager 추가 (first page 캐싱)
  *
- * Redis 설정을 담당한다.
- * 분산 락과 캐싱에 StringRedisTemplate을 사용한다.
+ * Redis 설정을 담당한다. 분산 락/타임아웃에는 StringRedisTemplate, 응답 캐싱에는 RedisCacheManager 를 사용한다.
  *
- * Redis 구현체 비교:
- *
- * Lettuce (현재 사용)
- *   - 장점: 비동기/논블로킹, Netty 기반으로 하나의 커넥션을 멀티스레드에서 공유 가능, 커넥션 풀 없이도 높은 동시성 처리, Spring Boot 기본 내장
- *   - 단점: 디버깅이 상대적으로 어려움
- *
- * Jedis
- *   - 장점: 동기 방식으로 직관적, 오래된 라이브러리라 레퍼런스 풍부
- *   - 단점: 스레드별 커넥션 필요(커넥션 풀 필수), 동시 요청이 많으면 풀 고갈 위험, 멀티스레드 환경에서 thread-safe하지 않음
- *
- * 대용량 트래픽 환경에서 커넥션 효율이 중요하므로 Lettuce를 사용한다.
- * spring-boot-starter-data-redis가 기본으로 Lettuce를 내장하고 있어 별도 설정 없이 적용된다.
+ * Redis 구현체 비교
+ *   - Lettuce (현재 사용): 비동기/논블로킹, Netty 기반 커넥션 공유, 대용량 트래픽 친화
+ *   - Jedis: 동기, 스레드별 커넥션 필요, 멀티스레드 환경에서 비효율
+ *   대용량 트래픽 환경에서 커넥션 효율이 중요하므로 Lettuce 를 사용한다.
  */
 @Configuration
 public class RedisConfig {
@@ -32,5 +36,41 @@ public class RedisConfig {
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
+    }
+
+    /**
+     * Spring Cache 전용 CacheManager.
+     * - 키: String (사람이 읽기 쉬운 형태, 예: products:firstPage::20)
+     * - 값: JSON 직렬화 (GenericJacksonJsonRedisSerializer, Jackson 3.x)
+     *   타입 정보를 인라인 `@class` 프로퍼티(AsProperty)로 기록해 record/제네릭도 안전하게 역직렬화
+     *   (WrapperArray 방식은 final record 루트에서 타입 래퍼가 생략돼 역직렬화가 깨짐)
+     * - Spring Cache null marker 지원 활성화 (NullValue 직렬화)
+     * - 기본 TTL: 30초 (신상품 반영 지연 허용 범위)
+     * - null 값은 캐시하지 않음 (의미 없음)
+     */
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .activateDefaultTypingAsProperty(typeValidator, DefaultTyping.NON_FINAL, "@class")
+                .build();
+
+        GenericJacksonJsonRedisSerializer valueSerializer =
+                new GenericJacksonJsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(30))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(valueSerializer));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/src/main/java/ccommit/stylehub/product/repository/ProductQueryRepository.java
+++ b/src/main/java/ccommit/stylehub/product/repository/ProductQueryRepository.java
@@ -1,11 +1,12 @@
 package ccommit.stylehub.product.repository;
 
-import ccommit.stylehub.product.entity.Product;
+import ccommit.stylehub.product.dto.response.ProductListResponse;
 import ccommit.stylehub.product.entity.QProduct;
 import ccommit.stylehub.product.enums.MainCategory;
 import ccommit.stylehub.product.enums.SubCategory;
 import ccommit.stylehub.user.entity.QUser;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -15,10 +16,12 @@ import java.util.List;
 /**
  * @author WonJin Bae
  * @created 2026/03/27
+ * @modified 2026/04/24 by WonJin - perf: 엔티티 전체 조회 대신 Projections.constructor 로 8개 컬럼만 DTO 직접 투영 (31→8 컬럼, 과다 컬럼 투영 해소)
  *
  * <p>
  * QueryDSL 기반 상품 동적 조회를 담당한다.
  * 커서 기반 페이징과 다중 필터(스토어, 카테고리)를 지원한다.
+ * 목록 조회에서 엔티티 전체를 가져오는 대신 ProductListResponse 로 직접 투영해 SELECT 컬럼 수를 최소화한다.
  * </p>
  */
 @Repository
@@ -28,13 +31,13 @@ public class ProductQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     // 스토어 필터만 적용 (카테고리 없이 조회)
-    public List<Product> findProductsWithCursor(Long cursor, Long storeId, int size) {
+    public List<ProductListResponse> findProductsWithCursor(Long cursor, Long storeId, int size) {
         return findProductsWithCursor(cursor, storeId, null, null, size);
     }
 
-    public List<Product> findProductsWithCursor(Long cursor, Long storeId,
-                                                 MainCategory mainCategory,
-                                                 SubCategory subCategory, int size) {
+    public List<ProductListResponse> findProductsWithCursor(Long cursor, Long storeId,
+                                                            MainCategory mainCategory,
+                                                            SubCategory subCategory, int size) {
         QProduct product = QProduct.product;
         QUser user = QUser.user;
 
@@ -54,8 +57,17 @@ public class ProductQueryRepository {
         }
 
         return queryFactory
-                .selectFrom(product)
-                .join(product.user, user).fetchJoin()
+                .select(Projections.constructor(ProductListResponse.class,
+                        product.productId,
+                        user.userId,            // storeId
+                        user.storeName,         // storeName
+                        product.name,
+                        product.mainCategory,
+                        product.subCategory,
+                        product.price,
+                        product.imageUrl))
+                .from(product)
+                .join(product.user, user)
                 .where(builder)
                 .orderBy(product.productId.desc())
                 .limit(size)

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -108,15 +108,21 @@ public class ProductService implements ProductPort {
      * 커서 기반 상품 목록을 조회한다. 스토어, 카테고리 필터링 지원. (비인증 공개 API)
      *
      * 캐시 전략:
-     *   필터가 없는 "첫 페이지" 요청(cursor / storeId / mainCategory / subCategory 모두 null)만 Redis 캐시 적용.
-     *   모든 사용자에게 동일 응답이 반환되고 호출 빈도가 매우 높은 구간이라 효과가 가장 크다.
-     *   TTL 30초 (RedisCacheManager 기본값) 로 신상품 반영 지연은 최대 30초.
-     *   다른 필터 조합은 개인별 편차가 크고 캐시 효율이 낮아 캐시하지 않는다.
+     *   커서가 없는 "첫 페이지" 요청을 필터 조합별로 캐시한다.
+     *   - 필터 없음(첫 페이지): 전 사용자 동일 응답, 호출 빈도 1위
+     *   - by category: 카테고리별 첫 페이지, 전 사용자 동일 응답
+     *   - by store: 스토어별 첫 페이지, 해당 스토어 방문자 간 공유
+     *   cursor 가 있는 "다음 페이지" 는 스크롤 분포가 분산돼 캐시 효율이 낮아 제외.
+     *
+     *   sync = true: TTL 만료 순간 cache miss 가 동시에 쏟아지는 thundering herd 를 차단한다.
+     *   같은 키로 동시 miss 가 발생하면 한 스레드만 DB 로 가고 나머지는 결과를 기다린다.
+     *   TTL 60 초 — 신상품 반영 지연 허용 범위. 1000 users 구간에서 miss 빈도를 절반으로 낮추기 위해 30 → 60 상향.
      */
     @Cacheable(
             value = "products:firstPage",
-            key = "#pageSize ?: 20",
-            condition = "#cursor == null && #storeId == null && #mainCategory == null && #subCategory == null"
+            key = "'size=' + (#pageSize ?: 20) + '|store=' + #storeId + '|main=' + #mainCategory + '|sub=' + #subCategory",
+            condition = "#cursor == null",
+            sync = true
     )
     @Transactional(readOnly = true)
     public CursorResponse<ProductListResponse> getProducts(Long cursor, Long storeId,
@@ -134,7 +140,17 @@ public class ProductService implements ProductPort {
     /**
      * 상품 상세 정보와 옵션 목록을 조회한다. (비인증 공개 API)
      * Store와 Options를 JOIN FETCH로 한번에 조회한다.
+     *
+     * 캐시 전략:
+     *   productId 별로 캐시 (모든 사용자에게 동일 응답). TTL 60초.
+     *   2,000 users 구간에서 이 경로가 전체 요청의 17 % 를 차지해 DB 부하의 주요 원인이라 캐시 대상으로 편입.
+     *   sync = true: 동시 cache miss 에서 한 스레드만 DB 로 가고 나머지는 대기 (thundering herd 차단).
      */
+    @Cacheable(
+            value = "products:detail",
+            key = "#productId",
+            sync = true
+    )
     @Transactional(readOnly = true)
     public ProductResponse getProduct(Long productId) {
         Product product = productRepository.findByIdWithUserAndOptions(productId)

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -32,6 +32,7 @@ import java.util.List;
  * @modified 2026/03/27 by WonJin - feat: 비관적 락 재고 차감/복구 메서드 추가
  * @modified 2026/04/01 by WonJin - refactor: ProductViewService를 ProductService로 통합
  * @modified 2026/04/22 by WonJin - refactor: UserPort 의존 제거, 권한 검증은 ProductApplicationService로 이관 (도메인 서비스는 자기 도메인만 알도록 분리)
+ * @modified 2026/05/01 by WonJin - refactor: @Cacheable 키 null 자리를 '*' sentinel 로 치환 (SpEL String concatenation 의 null → "null" 문자열 변환 방지)
  *
  * <p>
  * 상품 등록, 재고 관리, 조회를 담당하는 순수 도메인 서비스이다.
@@ -117,10 +118,17 @@ public class ProductService implements ProductPort {
      *   sync = true: TTL 만료 순간 cache miss 가 동시에 쏟아지는 thundering herd 를 차단한다.
      *   같은 키로 동시 miss 가 발생하면 한 스레드만 DB 로 가고 나머지는 결과를 기다린다.
      *   TTL 60 초 — 신상품 반영 지연 허용 범위. 1000 users 구간에서 miss 빈도를 절반으로 낮추기 위해 30 → 60 상향.
+     *
+     *   key 의 null 자리는 '*' sentinel 로 치환한다. SpEL 의 String concatenation 은 null 을 문자열 "null" 로
+     *   변환하므로, "필터 없음" 의 의도가 키에서 모호해질 수 있고 디버깅·로그 가독성이 떨어진다.
+     *   '*' 는 Long·Enum 어느 타입에도 등장하지 않는 sentinel 이라 충돌 가능성이 없다.
      */
     @Cacheable(
             value = "products:firstPage",
-            key = "'size=' + (#pageSize ?: 20) + '|store=' + #storeId + '|main=' + #mainCategory + '|sub=' + #subCategory",
+            key = "'size=' + (#pageSize ?: 20) " +
+                  "+ '|store=' + (#storeId ?: '*') " +
+                  "+ '|main=' + (#mainCategory ?: '*') " +
+                  "+ '|sub=' + (#subCategory ?: '*')",
             condition = "#cursor == null",
             sync = true
     )

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -18,6 +18,7 @@ import ccommit.stylehub.product.repository.ProductQueryRepository;
 import ccommit.stylehub.product.repository.ProductRepository;
 import ccommit.stylehub.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,13 +68,9 @@ public class ProductService implements ProductPort {
     public CursorResponse<ProductListResponse> getMyStoreProducts(Long storeId, Long cursor, Integer pageSize) {
         int resolvedSize = resolvePageSize(pageSize);
 
-        List<Product> products = productQueryRepository.findProductsWithCursor(
+        List<ProductListResponse> productList = productQueryRepository.findProductsWithCursor(
                 cursor, storeId, resolvedSize + 1
         );
-
-        List<ProductListResponse> productList = products.stream()
-                .map(ProductListResponse::from)
-                .toList();
 
         return CursorResponse.of(productList, resolvedSize, ProductListResponse::productId);
     }
@@ -109,20 +106,27 @@ public class ProductService implements ProductPort {
 
     /**
      * 커서 기반 상품 목록을 조회한다. 스토어, 카테고리 필터링 지원. (비인증 공개 API)
+     *
+     * 캐시 전략:
+     *   필터가 없는 "첫 페이지" 요청(cursor / storeId / mainCategory / subCategory 모두 null)만 Redis 캐시 적용.
+     *   모든 사용자에게 동일 응답이 반환되고 호출 빈도가 매우 높은 구간이라 효과가 가장 크다.
+     *   TTL 30초 (RedisCacheManager 기본값) 로 신상품 반영 지연은 최대 30초.
+     *   다른 필터 조합은 개인별 편차가 크고 캐시 효율이 낮아 캐시하지 않는다.
      */
+    @Cacheable(
+            value = "products:firstPage",
+            key = "#pageSize ?: 20",
+            condition = "#cursor == null && #storeId == null && #mainCategory == null && #subCategory == null"
+    )
     @Transactional(readOnly = true)
     public CursorResponse<ProductListResponse> getProducts(Long cursor, Long storeId,
                                                            MainCategory mainCategory,
                                                            SubCategory subCategory, Integer pageSize) {
         int resolvedSize = resolvePageSize(pageSize);
 
-        List<Product> products = productQueryRepository.findProductsWithCursor(
+        List<ProductListResponse> productList = productQueryRepository.findProductsWithCursor(
                 cursor, storeId, mainCategory, subCategory, resolvedSize + 1
         );
-
-        List<ProductListResponse> productList = products.stream()
-                .map(ProductListResponse::from)
-                .toList();
 
         return CursorResponse.of(productList, resolvedSize, ProductListResponse::productId);
     }


### PR DESCRIPTION
 ## #️⃣Issue Number

  - #21 

  ## 📝 요약(Summary)
 - 300만 건 상품 데이터에서 50 users 접속 시 응답 시간 128배 악화되던 상품 조회 API 성능 개선
 - 7단계 순차 개선 적용 (인덱스 · Projection · HikariCP 풀 · Covering Index · Redis 캐시 계층화 · sync=true · Tomcat 스레드 튜닝)
 - 50 users 기준 5 개 API 전부 P95 < 300 ms 달성 (최대 500× 단축, RPS 3.7× 증가)
 - 단일 서버 실용 상한 확정: 2,000 users / 1,003 RPS / P95 1,000 ms
 - 극한 스트레스 테스트(10,000 users)에서도 104,157 요청 실패 0 건 graceful degradation 실측 증명          


  ## 🛠️PR 유형
 어떤 변경 사항이 있나요?

  - [ ] 새로운 기능 추가
  - [ ] 버그 수정
  - [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
  - [x] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [ ] 테스트 추가, 테스트 리팩토링
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

---
  ## 주요 설계 결정
 1. QueryDSL Projection 적용 (N+1 가설 번복)                                                                                                                                      
                                      
  - 초기 가설은 N+1 이었으나 show-sql 로그 확인 결과 실제 원인은 단일 쿼리 내 31 컬럼 과다 투영                                                                                    
  - .selectFrom(product).fetchJoin() → Projections.constructor(ProductListResponse.class, ...) 로 8 컬럼만 투영
  - password, description(TEXT), store_description 등 불필요 컬럼 제거로 보안·성능 동시 개선                                                                                       
                                                                                                                                                                                   
  2. Covering Index 로 DB 테이블 접근 제거               
                                                                                                                                                                                   
  - idx_products_category → idx_products_category_cover (main_category, sub_category, product_id DESC, user_id, name, price, image_url)
  - EXPLAIN 의 Extra 에 Using index 가 찍혀 테이블 방문 없이 인덱스만으로 조회 완료
  - 쓰기 비용 증가 트레이드오프 수용 (상품 조회는 읽기 위주 워크로드)                                                                                                              
                                         
  3. Redis 캐시 범위 단계적 확장                                                                                                                                                   
                                                                                   
  - 초기: first page (필터 없는 첫 페이지) 만 → 50 users 해소                                                                                                                      
  - 500 users 대응: cursor == null 인 모든 첫 페이지로 확장 (by category / by store 포함, 필터 조합별 키)                                                                          
  - 1,000 users 대응: @Cacheable(sync = true) 로 동시 cache miss 직렬화 — cache stampede 차단                                                                                      
  - 2,000 users 대응: /products/{id} 단건 상세에도 캐시 적용                                                                                                                       
  - TTL 60 초 (신상품 반영 지연 허용 범위)                                                                                                                                         
                                                                                   
  4. Jackson 3 호환 타입드 직렬화기 자체 구현                                                                                                                                      
                                                                                                                                                                                   
  - Spring Boot 4.0.3 의 Jackson 3 전환 후 DefaultTyping.EVERYTHING 제거로 record 직렬화 불가능                                                                                    
  - activateDefaultTyping(NON_FINAL) 은 final record 에서 타입 정보 생략 → 99 % 실패 재현                                                                                          
  - 해결: 캐시별 고정 JavaType 기반 RedisSerializer 자체 구현 (default typing 비의존)                                                                                              
  - RedisCacheManager.withInitialCacheConfigurations 로 목록 / 상세 캐시 각각 다른 타입 등록
                                                                                                                                                                                   
  5. 병목 이동 구조에 따른 단계적 튜닝   
  6.  확장성 실측 및 scale-out 경계 문서화  
   -  2,000 users 이상 구간은 Read Replica · 애플리케이션 수평 확장 · CDN/엣지 캐시 영역으로 설계 문서화 (scale-out 으로 해결해야 하는 경계선 명시).                                   
                                                                                   
---  
## 측정 방법
-  Locust 로 Warm-up → Light → Medium → Heavy → Spike 단계별 부하 시나리오 실행, 각 Step 마다 Before / After 독립 측정으로 개별 기여도 분리 확인                  
                                                                                                                                                                                   
 ## 관련 블로그                                                                                                                                                                  
  - 상품조회블로그성능.md (단계별 과정 · 가설 검증 · 삽질 기록)                                                                                                            
  
                                  
                                                                                                           