### PR TITLE
Refactor/주문결제 api 성능측정

### DIFF
--- a/performance/locustfile_order.py
+++ b/performance/locustfile_order.py
@@ -1,0 +1,264 @@
+"""
+시나리오 2: 주문 → 결제 (비관적 락 한계 측정)
+
+측정 목표
+  - 비관적 락(SELECT FOR UPDATE) 기반 재고 차감의 TPS 한계
+  - 동일 옵션 동시 주문 시 락 대기 시간 분포
+  - 동시성 100/300 user 구간에서 HikariCP 풀 사용률 추이
+  - 정합성: 주문 수량 합 == 차감된 재고
+
+측정 범위 (placeOrder 만)
+  - 결제 승인(GET /payments/success) 은 토스 sandbox API 호출이 발생하므로 부하 테스트 부적합
+  - 시나리오 2 의 핵심(비관적 락 + 재고 차감) 은 placeOrder 단계에 모두 있어 의미 있는 측정 가능
+  - PG mock 모드(todo.md) 가 도입되면 confirmPayment 까지 확장 가능
+
+사전 준비
+  1. seed-test-buyers.sql 실행
+       mysql -u root -p stylehub < performance/seed-test-buyers.sql
+  2. 상품/옵션 데이터 존재 확인 (product-bulk-insert.sql 로 사전 생성 가정)
+  3. pymysql / requests / locust 설치
+       pip install pymysql locust requests
+
+실행 방법
+  # 웹 UI
+  locust -f performance/locustfile_order.py --host=http://localhost:8080
+
+  # Headless 부하 단계 (시나리오 문서 기준)
+  # 기본 — 정합성 확인
+  locust -f performance/locustfile_order.py --host=http://localhost:8080 \\
+         --headless -u 10 -r 5 -t 2m \\
+         --csv=performance/results/order_baseline_10
+
+  # 같은 옵션 집중 — 락 경합
+  locust -f performance/locustfile_order.py --host=http://localhost:8080 \\
+         --headless -u 50 -r 25 -t 3m \\
+         --csv=performance/results/order_concentrated_50
+
+  # 옵션 분산 — 한계 TPS 탐색
+  locust -f performance/locustfile_order.py --host=http://localhost:8080 \\
+         --headless -u 100 -r 50 -t 5m \\
+         --csv=performance/results/order_spread_100
+
+  # 스트레스
+  locust -f performance/locustfile_order.py --host=http://localhost:8080 \\
+         --headless -u 300 -r 100 -t 5m \\
+         --csv=performance/results/order_stress_300
+
+검증 쿼리 (테스트 후)
+  -- 주문 수량 합 vs 차감된 재고 (정합성)
+  SELECT po.product_option_id, po.stock_quantity,
+         (SELECT SUM(od.quantity) FROM order_details od
+          WHERE od.product_option_id = po.product_option_id) AS sold
+  FROM products_options po
+  WHERE po.product_option_id IN ({테스트 옵션 ID 목록});
+  -- 기대: stock_quantity + sold == 초기 재고
+
+  -- 주문 상태별 카운트
+  SELECT order_status, COUNT(*) FROM orders
+  WHERE created_at >= '{테스트 시작 시각}'
+  GROUP BY order_status;
+
+  -- 락 대기로 인한 timeout/실패 점검 (HikariCP 메트릭)
+  -- /actuator/metrics/hikaricp.connections.timeout
+"""
+import os
+import random
+import threading
+from collections import deque
+
+import requests
+from locust import HttpUser, task, between, events
+
+
+# ============================================
+# 환경 변수 (실행 시 override 가능)
+# ============================================
+DB_HOST = os.environ.get("PERF_DB_HOST", "localhost")
+DB_PORT = int(os.environ.get("PERF_DB_PORT", "3306"))
+DB_USER = os.environ.get("PERF_DB_USER", "root")
+DB_PASSWORD = os.environ.get("PERF_DB_PASSWORD", "")
+DB_NAME = os.environ.get("PERF_DB_NAME", "stylehub")
+
+BUYER_PASSWORD = "Test1234!"
+HOT_OPTION_RATIO = float(os.environ.get("PERF_HOT_OPTION_RATIO", "0.5"))
+# 0.5 = 절반의 주문은 hot option(1개) 으로 몰아서 락 경합 유도
+# 1.0 = 모든 주문이 단일 hot option (가장 강한 경합)
+# 0.0 = 모든 주문이 무작위 옵션 (분산)
+
+
+# ============================================
+# 글로벌 상태 — test_start 에서 채움
+# ============================================
+SESSION_POOL: "deque[tuple[int, int, dict]]" = deque()
+SESSION_POOL_LOCK = threading.Lock()
+OPTION_IDS: list[int] = []
+HOT_OPTION_ID: int | None = None
+
+
+@events.test_start.add_listener
+def setup_session_pool(environment, **kwargs):
+    """
+    테스트 시작 전 1회 실행 — 모든 setup 호출은 raw requests / pymysql 로
+    Locust stats 격리. 부하 측정에는 placeOrder 만 카운트된다.
+
+    절차:
+      1) DB 에서 perf buyer 의 (user_id, address_id) 쌍 조회
+      2) 사용 가능한 product_option_id 목록 + 가장 재고 많은 hot option 선정
+      3) 모든 buyer 를 raw POST /users/login 으로 동시 로그인 → 세션 쿠키 확보
+      4) (user_id, address_id, cookies) 튜플을 SESSION_POOL deque 에 적재
+    """
+    host = environment.host
+    if not host:
+        print("[setup] host 가 설정되지 않아 셋업을 건너뜁니다.")
+        return
+
+    try:
+        import pymysql
+    except ImportError:
+        print("[setup] pymysql 미설치 — pip install pymysql 필요. 셋업 중단.")
+        return
+
+    # 1) DB 에서 buyer / option 정보 수집
+    conn = pymysql.connect(
+        host=DB_HOST, port=DB_PORT, user=DB_USER,
+        password=DB_PASSWORD, db=DB_NAME, charset="utf8mb4",
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT u.user_id, MIN(a.address_id) AS address_id, u.email
+                FROM users u
+                JOIN addresses a ON a.user_id = u.user_id
+                WHERE u.email LIKE 'perf_buyer_%@perf.test'
+                GROUP BY u.user_id, u.email
+            """)
+            buyers = cur.fetchall()  # [(user_id, address_id, email), ...]
+
+            # 옵션 풀은 store(user) FK 가 살아있는 옵션만 선택한다.
+            # 시드 데이터에 dangling FK 가 섞여 있어 (products.user_id → users 미존재) 이를 거르지 않으면
+            # OrderService 가 store 정보를 LAZY 로드할 때 5xx 가 발생해 시스템 한계가 아닌 데이터 결함이 측정에 노출된다.
+            cur.execute("""
+                SELECT po.product_option_id, po.stock_quantity
+                FROM products_options po
+                JOIN products p ON p.product_id = po.product_id
+                JOIN users u ON u.user_id = p.user_id
+                WHERE po.stock_quantity > 0
+                  AND u.role = 'STORE'
+                ORDER BY po.stock_quantity DESC
+                LIMIT 200
+            """)
+            options = cur.fetchall()  # [(option_id, stock), ...]
+    finally:
+        conn.close()
+
+    if not buyers:
+        print("[setup] perf buyer 가 0명입니다. seed-test-buyers.sql 을 먼저 실행해주세요.")
+        return
+    if not options:
+        print("[setup] 재고 있는 product option 이 없습니다. product/option 시드 필요.")
+        return
+
+    global OPTION_IDS, HOT_OPTION_ID
+    OPTION_IDS = [opt[0] for opt in options]
+    HOT_OPTION_ID = options[0][0]  # 재고 가장 많은 옵션을 hot option 으로
+    print(f"[setup] buyer {len(buyers)}명, option pool {len(OPTION_IDS)}개, "
+          f"hot option_id={HOT_OPTION_ID} (stock={options[0][1]})")
+
+    # 2) 모든 buyer 를 미리 로그인 → 세션 쿠키 풀 구축
+    success = 0
+    for user_id, address_id, email in buyers:
+        try:
+            res = requests.post(
+                f"{host}/api/v1/users/login",
+                json={"email": email, "password": BUYER_PASSWORD},
+                timeout=10,
+            )
+            if res.status_code != 200:
+                print(f"[setup] login 실패 user_id={user_id} status={res.status_code}")
+                continue
+            cookies = res.cookies.get_dict()
+            with SESSION_POOL_LOCK:
+                SESSION_POOL.append((user_id, address_id, cookies))
+            success += 1
+        except requests.RequestException as e:
+            print(f"[setup] login 예외 user_id={user_id} err={e}")
+
+    print(f"[setup] 세션 풀 구축 완료: {success}/{len(buyers)}명 로그인 성공")
+
+
+def acquire_session() -> "tuple[int, int, dict] | None":
+    """SESSION_POOL 에서 한 사용자 분량을 꺼낸다 (thread-safe)."""
+    with SESSION_POOL_LOCK:
+        if not SESSION_POOL:
+            return None
+        return SESSION_POOL.popleft()
+
+
+def release_session(session_tuple) -> None:
+    """사용자 종료 시 세션을 풀에 반납해 다음 VU 가 재사용한다."""
+    with SESSION_POOL_LOCK:
+        SESSION_POOL.append(session_tuple)
+
+
+class OrderUser(HttpUser):
+    # wait_time 단축 측정용: 부하 클라이언트의 wait_time 천장 제거 → 시스템의 진짜 RPS 한계 측정
+    # 기존 between(0.5, 2.0) 은 50 users 시 이론 RPS 40 천장에 갇혀 락 제거 효과가 안 보였음
+    # 0.05~0.2 로 단축하면 50 users 가 full throttle 에 가까워져 시스템 한계 측정 가능
+    wait_time = between(0.05, 0.2)
+
+    def on_start(self):
+        """각 VU 가 시작 시 세션 풀에서 자기 credentials 를 받아온다."""
+        session = acquire_session()
+        if session is None:
+            print("[VU] 세션 풀 고갈 — buyer 수보다 많은 VU 를 띄우셨거나 setup 실패")
+            self.environment.runner.quit()
+            return
+        self.user_id, self.address_id, cookies = session
+        self.client.cookies.update(cookies)
+        # on_stop 에서 반납하기 위해 보관
+        self._session_tuple = session
+
+    def on_stop(self):
+        if hasattr(self, "_session_tuple"):
+            release_session(self._session_tuple)
+
+    @task(8)
+    def place_order_hot_option(self):
+        """가중치 8: hot option 에 집중 → 락 경합 유도"""
+        if HOT_OPTION_ID is None:
+            return
+        # HOT_OPTION_RATIO 에 따라 hot option vs 무작위 분배
+        if random.random() < HOT_OPTION_RATIO:
+            option_id = HOT_OPTION_ID
+        else:
+            option_id = random.choice(OPTION_IDS)
+
+        self._post_order(option_id, name="POST /orders (hot)")
+
+    @task(2)
+    def place_order_random_option(self):
+        """가중치 2: 무작위 옵션 → 분산 부하 (한계 TPS 측정)"""
+        option_id = random.choice(OPTION_IDS)
+        self._post_order(option_id, name="POST /orders (random)")
+
+    def _post_order(self, option_id: int, name: str):
+        payload = {
+            "addressId": self.address_id,
+            "details": [
+                {"productOptionId": option_id, "quantity": 1}
+            ],
+        }
+        with self.client.post(
+            "/api/v1/orders/orders",
+            json=payload,
+            name=name,
+            catch_response=True,
+        ) as response:
+            # 의도된 실패(409 INSUFFICIENT_STOCK) 와 진짜 에러(5xx, timeout) 분리
+            if response.status_code == 200 or response.status_code == 201:
+                response.success()
+            elif response.status_code == 409:
+                # 재고 소진은 비즈니스 정상 응답 — Locust 통계에서 success 처리
+                response.success()
+            else:
+                response.failure(f"unexpected status={response.status_code}")

--- a/performance/seed-test-buyers.sql
+++ b/performance/seed-test-buyers.sql
@@ -1,0 +1,76 @@
+-- ============================================
+-- 시나리오 2 (주문 → 결제) 부하 테스트용 buyer 시드
+--
+-- 생성:
+--   - users 500명: email perf_buyer_1@perf.test ~ perf_buyer_500@perf.test
+--   - addresses 500건: 각 buyer 당 1개 (default)
+--
+-- 비밀번호: Test1234!
+--   BCrypt cost 10 해시. Java BCrypt 라이브러리(at.favre.lib.crypto.bcrypt)는
+--   $2a, $2b, $2y prefix 모두 지원하므로 호환된다.
+--
+-- 사용:
+--   mysql -u root -p stylehub < performance/seed-test-buyers.sql
+--
+-- 멱등성:
+--   기존 perf_buyer_*@perf.test 행을 먼저 삭제 후 재생성하므로 반복 실행 안전.
+--   addresses 는 FK(user_id) 로 연결되어 user 삭제 시 함께 정리되도록
+--   먼저 명시적으로 삭제한다.
+-- ============================================
+
+-- 1. 기존 perf_buyer 데이터 정리 (멱등성)
+DELETE FROM addresses
+WHERE user_id IN (
+    SELECT user_id FROM users WHERE email LIKE 'perf_buyer_%@perf.test'
+);
+DELETE FROM users WHERE email LIKE 'perf_buyer_%@perf.test';
+
+-- 2. buyer 500명 생성
+--    10x10x5 sequence 로 1..500 생성, 동일 BCrypt 해시 사용 (single hash 빠름)
+INSERT INTO users (
+    name, email, password, role, grade,
+    total_spent, point_balance, is_active,
+    created_at, updated_at
+)
+SELECT
+    CONCAT('perf_buyer_', seq),
+    CONCAT('perf_buyer_', seq, '@perf.test'),
+    '$2y$10$IaHd2MOHqgjP4HhXBijo4uJ00fPrcZLNX7hMTkUVJHhPygbJSYUpO',
+    'USER', 'BRONZE',
+    0, 0, true,
+    NOW(), NOW()
+FROM (
+    SELECT a.N + b.N * 10 + c.N * 100 + 1 AS seq
+    FROM (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+          UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a,
+         (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+          UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b,
+         (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4) c
+) nums
+WHERE seq <= 500;
+
+-- 3. 각 buyer 당 address 1건 생성 (default 배송지)
+INSERT INTO addresses (
+    user_id, label, recipient_name, phone,
+    zip_code, street_address, detail_address,
+    is_default, created_at, updated_at
+)
+SELECT
+    u.user_id,
+    '집',
+    u.name,
+    '010-0000-0000',
+    '12345',
+    '서울시 강남구 테헤란로 1',
+    CONCAT('테스트동 ', SUBSTRING(u.email, 12), '호'),
+    true,
+    NOW(), NOW()
+FROM users u
+WHERE u.email LIKE 'perf_buyer_%@perf.test';
+
+-- 4. 검증 쿼리 (선택 — 결과만 확인)
+SELECT
+    (SELECT COUNT(*) FROM users WHERE email LIKE 'perf_buyer_%@perf.test') AS buyer_count,
+    (SELECT COUNT(*) FROM addresses WHERE user_id IN
+        (SELECT user_id FROM users WHERE email LIKE 'perf_buyer_%@perf.test')) AS address_count;
+-- 기대: buyer_count = 500, address_count = 500

--- a/src/main/java/ccommit/stylehub/product/repository/ProductOptionRepository.java
+++ b/src/main/java/ccommit/stylehub/product/repository/ProductOptionRepository.java
@@ -4,6 +4,7 @@ import ccommit.stylehub.product.entity.ProductOption;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,7 @@ import java.util.Optional;
  * @author WonJin Bae
  * @created 2026/03/25
  * @modified 2026/03/27 by WonJin - feat: findByProductProductId 조회, 비관적 락 조회 메서드 추가
+ * @modified 2026/05/03 by WonJin - perf: decreaseStockAtomic 추가 — SELECT FOR UPDATE 비관적 락 제거, 단일 atomic UPDATE 로 락 점유 시간 0 화
  *
  * <p>
  * ProductOption 엔티티의 데이터 접근을 담당한다.
@@ -25,9 +27,22 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
 
     List<ProductOption> findByProductProductId(Long productId);
 
-    // 비관적 락(SELECT FOR UPDATE)으로 옵션, 상품, 스토어를 함께 조회한다. (재고 수정 시 사용)
+    // 비관적 락(SELECT FOR UPDATE)으로 옵션, 상품, 스토어를 함께 조회한다. (updateStock — 재고 수동 변경 시 사용)
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT po FROM ProductOption po JOIN FETCH po.product p JOIN FETCH p.user WHERE po.productOptionId = :optionId")
     Optional<ProductOption> findByIdWithLock(@Param("optionId") Long optionId);
+
+    /**
+     * 재고를 단일 atomic UPDATE 로 차감한다. 비관적 락 대신 사용.
+     * - DB 가 단일 UPDATE 를 atomic 으로 처리 → race condition 자체가 발생 불가능
+     * - WHERE stock_quantity >= :qty 조건이 음수 재고 방지 (SOLD_OUT 케이스도 자연스럽게 처리)
+     * - 락 점유 시간 = 0 → SELECT FOR UPDATE 시절의 락 대기가 사라짐
+     *
+     * @return 1 = 차감 성공, 0 = 옵션 없거나 재고 부족 (호출자가 구분 처리 필요)
+     */
+    @Modifying
+    @Query("UPDATE ProductOption po SET po.stockQuantity = po.stockQuantity - :qty " +
+           "WHERE po.productOptionId = :optionId AND po.stockQuantity >= :qty")
+    int decreaseStockAtomic(@Param("optionId") Long optionId, @Param("qty") int qty);
 
 }

--- a/src/main/java/ccommit/stylehub/product/service/ProductService.java
+++ b/src/main/java/ccommit/stylehub/product/service/ProductService.java
@@ -31,6 +31,7 @@ import java.util.List;
  * @modified 2026/03/27 by WonJin - feat: 비관적 락 재고 차감/복구 메서드 추가
  * @modified 2026/04/01 by WonJin - refactor: ProductViewService를 ProductService로 통합
  * @modified 2026/04/22 by WonJin - refactor: UserPort 의존 제거, 권한 검증은 ProductApplicationService로 이관 (도메인 서비스는 자기 도메인만 알도록 분리)
+ * @modified 2026/05/03 by WonJin - perf: decreaseStockWithLock 을 SELECT FOR UPDATE 비관적 락에서 단일 atomic UPDATE 로 전환 (락 점유 시간 0 → 동시 주문 처리량 향상)
  *
  * <p>
  * 상품 등록, 재고 관리, 조회를 담당하는 순수 도메인 서비스이다.
@@ -89,14 +90,33 @@ public class ProductService implements ProductPort {
         return ProductOptionResponse.from(target);
     }
 
-    // 비관적 락으로 재고를 차감한다. 호출자의 트랜잭션에 참여한다.
-    // TODO: 대용량 트래픽 대응 시 Redis DECR 원자적 연산으로 전환 예정
+    /**
+     * 단일 atomic UPDATE 로 재고를 차감한다. 호출자의 트랜잭션에 참여한다.
+     *
+     * <p>이전 구현: SELECT FOR UPDATE 비관적 락 → 차감 → flush 시 UPDATE (쿼리 2번 + 락 점유)
+     * <br>현재 구현: UPDATE WHERE stock >= qty 단일 쿼리 (락 점유 시간 0)
+     *
+     * <p>DB 가 단일 UPDATE 를 atomic 으로 처리하므로 race condition 자체가 발생하지 않는다.
+     * WHERE 절의 stock_quantity >= :qty 조건이 음수 재고 방지 역할을 겸한다.
+     *
+     * <p>차감 후 OrderDetail 생성을 위해 ProductOption 엔티티 1회 조회 (단순 SELECT, 락 없음).
+     * 다음 단계 개선 영역: OrderDetail.create 시그니처를 productOptionId + price 로 단순화하면 이 SELECT 도 제거 가능.
+     *
+     * <p>TODO: 더 큰 트래픽 (100k+ TPS) 대응 시 Redis DECR 원자 연산으로 전환 검토
+     */
     @Override
     public ProductOption decreaseStockWithLock(Long optionId, int quantity) {
-        ProductOption option = productOptionRepository.findByIdWithLock(optionId)
+        int updated = productOptionRepository.decreaseStockAtomic(optionId, quantity);
+        if (updated == 0) {
+            // 0건 = 옵션이 없거나 재고 부족 — 둘을 구분해서 정확한 에러 코드 반환
+            if (!productOptionRepository.existsById(optionId)) {
+                throw new BusinessException(ErrorCode.PRODUCT_OPTION_NOT_FOUND);
+            }
+            throw new BusinessException(ErrorCode.INSUFFICIENT_STOCK);
+        }
+        // OrderDetail FK + getProductPrice() 호출을 위해 1회 조회 (단순 SELECT)
+        return productOptionRepository.findById(optionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
-        option.decreaseStock(quantity);
-        return option;
     }
 
     // 비관적 락으로 재고를 복구한다. 주문 취소 시 사용.


### PR DESCRIPTION
                     
                                                                                                                                                                                             
  ## 📝 요약(Summary)                    
  - 재고 차감 동시성 제어를 *비관적 락 → atomic UPDATE* 로 전환 + JDBC/Hibernate 튜닝                                                                                                        
  - 50 users 기준 RPS **8.8 배** (39.9 → 352.9), P99 **3 배 단축** (210 → 70 ms)   
  - 8 회 측정 누적 ~30 만 reqs **음수 재고 0 건** (정합성 100 % 유지)                                                                                                                        
  - 50/100/200 users saturation 곡선 정량화 (RPS 353 → 308 → 502 / Median 10 → 20 → 89 ms)                                                                                                   
                                                                                                                                                                                             
  ## 🛠 PR 유형                                                                                                                                                                              
  - [x] 코드 리팩토링                                                                                                                                                                        
  - [x] 문서 수정                                                                                                                                                                            
                                                                                                                                                                                             
  ---                                                                                                                                                                                        
                                                                                                                                                                                             
  ## 주요 설계 결정
                                                                                                                                                                                             
  ### 1. 비관적 락 → atomic UPDATE                                                 
  - `SELECT FOR UPDATE` 의 *락 점유 시간* 을 0 으로 만들기 위해 단일 `UPDATE WHERE stock >= qty` 로 전환
  - DB 가 atomic 으로 처리해 race 자체 발생 불가 + WHERE 조건이 음수 재고 방지 겸함                                                                                                          
  - 호출 인터페이스 (`decreaseStockWithLock`) 유지 — *내부 구현만* 교체
                                                                                                                                                                                             
  ### 2. JDBC + Hibernate batch 튜닝 (설정 5 줄)                                                                                                                                             
  - `useServerPrepStmts` / `cachePrepStmts` / `rewriteBatchedStatements` + Hibernate `batch_size=50` / `order_inserts/updates`                                                               
  - 코드 변경 0 줄, RPS 8.8 배 효과 (wait_time 단축 측정 환경에서 가시화)                                                                                                                    
                                                   
                                                                                                                                                                                             
  ---                                                                                                                                                                                        
                                                                                                                                                                                             
  ## 측정 방법                                                                                                                                                                               
  - Locust 8 회 사이클 (10 → 50 → 100 → 50 atomic → 50 튜닝 → 100 → 200 users)                                                                                                               
  - 매 사이클 Before/After 독립 측정 + 누적 reqs 에서 음수 재고 SQL 검증              